### PR TITLE
Fix: limit oil pressure display to 9.9 bar / 油圧表示の上限を9.9barに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays:
 
-* **Oil / Fuel / Boost Pressure** via **Defi PDF00903S** (0 – 10 bar, 0.5 – 4.5 V)  
+* **Oil / Fuel / Boost Pressure** via **Defi PDF00903S** (0 – 9.9 bar, 0.5 – 4.5 V)
 * **Oil / Water Temperature** via **Defi PDF00703S** (–40 – 150 °C, 0.5 – 4.5 V)  
 
 
@@ -19,7 +19,7 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 サーキットでの簡易モニタリング用途に最適化しています。
 
 ### 主な機能
-- 油圧・燃圧・ブースト (0–10 bar) 半円アナログメーター  
+- 油圧・燃圧・ブースト (0–9.9 bar) 半円アナログメーター
   - 本リポジトリでは **油圧**・**油温** を実装済み
 - 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
 - 各種設定は `src/main.cpp` 冒頭の定数で変更可能
@@ -43,13 +43,13 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 ### Overview
 This project turns an **M5Stack CoreS3** and **ADS1015 ADC** into a simple yet powerful multi-gauge that reads:
 
-- **Oil / Fuel / Boost Pressure** using **Defi PDF00903S** (0.5–4.5 V, 0–10 bar)  
+- **Oil / Fuel / Boost Pressure** using **Defi PDF00903S** (0.5–4.5 V, 0–9.9 bar)
 - **Oil / Water Temperature** using **Defi PDF00703S** (0.5–4.5 V, –40 to 150°C)  
 
 Perfect for vintage cars lacking modern instrumentation or for lightweight track-day data monitoring.
 
 ### Features
-- Semi-circular analog gauge (0–10 bar, pressure)
+- Semi-circular analog gauge (0–9.9 bar, pressure)
   - In this repository, **oil pressure** and **oil temperature** are implemented.
 - Digital + bar graph temperature display  
 - Settings are defined at the top of `src/main.cpp`

--- a/include/config.h
+++ b/include/config.h
@@ -29,6 +29,10 @@ constexpr uint16_t COLOR_YELLOW = rgb565(255, 255, 0);
 constexpr uint16_t COLOR_RED    = rgb565(255,   0, 0);
 constexpr uint16_t COLOR_GRAY   = rgb565(169, 169, 169);
 
+// ── 油圧表示上限 ──
+// メーターおよび数値表示が 9.9 bar を超えないようにする
+constexpr float MAX_OIL_PRESSURE_DISPLAY = 9.9f;
+
 // ── 画面サイズ ──
 constexpr int LCD_WIDTH  = 320;
 constexpr int LCD_HEIGHT = 240;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
 
   if (pressureChanged) {
     mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
-    drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, 10.0f,  8.0f,
+    drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_DISPLAY,  8.0f,
                      RED, "BAR", "OIL.P", recordedMaxOilPressure,
                      0.5f, true,   0,   60);
     displayCache.pressureAvg = pressureAvg;
@@ -379,6 +379,8 @@ void updateGauges()
   unsigned long now = millis();
 
   float pressureAvg      = calculateAverage(oilPressureSamples);
+  // 表示上の上限を超えないようにクランプ
+  pressureAvg = std::min(pressureAvg, MAX_OIL_PRESSURE_DISPLAY);
   float targetWaterTemp  = calculateAverage(waterTemperatureSamples);
   float targetOilTemp    = calculateAverage(oilTemperatureSamples);
 


### PR DESCRIPTION
## Summary / 概要
- clamp oil pressure value and gauge to MAX_OIL_PRESSURE_DISPLAY
- document 0–9.9 bar range in README

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851303673a0832294f745bce6ec15ea