### PR TITLE
Fix indentation in PlatformIO config / PlatformIO設定のインデント修正

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,9 +13,9 @@ platform = espressif32
 board = m5stack-cores3
 framework = arduino
 lib_deps =
-	m5stack/M5Unified@^0.1.17
-	m5stack/M5CoreS3@^1.0.0
-	adafruit/Adafruit ADS1X15@^2.5.0
+  m5stack/M5Unified@^0.1.17
+  m5stack/M5CoreS3@^1.0.0
+  adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep
 monitor_speed = 115200
 upload_port = COM11


### PR DESCRIPTION
## Summary / 概要
- replace tabs with two spaces in `platformio.ini`

## Testing
- `pip install platformio`
- `pio run -e m5stack-cores3` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851536135f88322831dc374c1e0b51f