### PR TITLE
Fix oil pressure decimal display | 油圧表示の小数点を修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,9 +155,11 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
 
   if (pressureChanged) {
     mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+    // 10.0以上は小数点を表示しない
+    bool useDecimal = pressureAvg < 10.0f;
     drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_METER,  8.0f,
                      COLOR_RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                     0.5f, true,   0,   60);
+                     0.5f, useDecimal,   0,   60);
     displayCache.pressureAvg = pressureAvg;
   }
 


### PR DESCRIPTION
## Summary
- Adjusted oil pressure gauge so it hides decimals at 10.0 bar or above

## 概要
- 油圧が10.0以上の場合、小数点を表示しないよう変更しました


------
https://chatgpt.com/codex/tasks/task_e_6852a2b6a2388322a367b3f7723bcb8a