### PR TITLE
Add tests and CI step / テスト追加とCI対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
         run: pip install platformio
       - name: Build
         run: pio run -e m5stack-cores3
+      - name: Run tests
+        run: pio test -e native

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,6 @@ lib_deps =
 lib_ldf_mode = deep
 monitor_speed = 115200
 upload_port = COM11
+
+[env:native]
+platform = native

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,24 @@
+#include <unity.h>
+#include "config.h"  // 色変換テスト用の設定
+#include "sensor.h"  // 平均計算のテンプレート
+
+// rgb565 関数のテスト
+void test_rgb565() {
+    TEST_ASSERT_EQUAL_UINT16(0xF800, rgb565(255, 0, 0));
+    TEST_ASSERT_EQUAL_UINT16(0x07E0, rgb565(0, 255, 0));
+    TEST_ASSERT_EQUAL_UINT16(0x001F, rgb565(0, 0, 255));
+}
+
+// calculateAverage テンプレートのテスト
+void test_calculate_average() {
+    float values[5] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 3.0f, calculateAverage(values));
+}
+
+// Unity テストランナー
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_rgb565);
+    RUN_TEST(test_calculate_average);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary / 概要
- add native environment for PlatformIO
- create basic unit tests for rgb565 and calculateAverage
- run tests in GitHub Actions workflow

## Testing / テスト
- `pio test -e native` *(failed: network restriction)*
- `pio run -e m5stack-cores3` *(failed: network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_685935081e188322926b4d3799befd1b