### PR TITLE
接続不良時のErr表示 / Show Err on sensor failure

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -67,4 +67,9 @@ constexpr int PRESSURE_SAMPLE_SIZE   = 5;
 constexpr int WATER_TEMP_SAMPLE_SIZE = 2;  // 500ms間隔×10サンプルで約5秒平均
 constexpr int OIL_TEMP_SAMPLE_SIZE   = 2;  // 500ms間隔×10サンプルで約5秒平均
 
+// ── 異常判定用閾値 ──
+// サンプル間の差がこの値を超えると接続不良とみなす
+constexpr float PRESSURE_ERR_THRESHOLD = 2.0f;  // 油圧用 [bar]
+constexpr float TEMP_ERR_THRESHOLD     = 20.0f; // 温度用 [℃]
+
 #endif // CONFIG_H

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -29,4 +29,17 @@ inline float calculateAverage(const float (&values)[N])
     return sum / static_cast<float>(N);
 }
 
+// サンプル間の差から値の乱れを検出
+template <size_t N>
+inline bool isErratic(const float (&values)[N], float threshold)
+{
+    float minV = values[0];
+    float maxV = values[0];
+    for (size_t i = 1; i < N; ++i) {
+        if (values[i] < minV) minV = values[i];
+        if (values[i] > maxV) maxV = values[i];
+    }
+    return (maxV - minV) > threshold;
+}
+
 #endif // SENSOR_H


### PR DESCRIPTION
## 概要 / Summary
- 異常値検出用閾値を追加
- センサー値が大きく乱れた場合は `Err` を表示
- `drawFillArcMeter` と油温バーで `Err` 表示をサポート

## Testing
- `pio run` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615b6503a88322bf1153aa6b854b26