### PR TITLE
Fix duplicate power setup / 電源初期化の重複を解消

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,12 +22,12 @@ void setup()
 
     M5.begin();
     CoreS3.begin(M5.config());
-    M5.Power.begin();
-    // 外部からの給電を利用する場合は 5V ピン出力を無効化
-    M5.Power.setExtOutput(false);
+
+    // 電源管理を初期化し、処理順序を明確にする
+    M5.Power.begin();           // まず電源モジュールを初期化
+    M5.Power.setExtOutput(false); // 外部給電時は 5V ピン出力を停止
+
     CoreS3.Ltr553.begin(&ltr553InitParams);
-    M5.Power.begin();
-    M5.Power.setExtOutput(false);
 
     display.init();
     // DMA を初期化


### PR DESCRIPTION
## Summary / 概要
- clean up duplicate `M5.Power.begin()` and `M5.Power.setExtOutput(false)` calls in `setup()`
- add Japanese comments showing initialization order

## Testing / テスト
- `platformio run` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e8da364a88322b92d293729758a0a