### PR TITLE
油温エラー時の表示修正 / Fix oil temp error display

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -165,8 +165,8 @@ void updateGauges()
     smoothOilTemp   += 0.1f * (targetOilTemp   - smoothOilTemp);
 
     float oilTempValue = smoothOilTemp;
-    if (!SENSOR_OIL_TEMP_PRESENT || oilTempValue >= 199.0f) {
-        // センサー異常時は 0 として扱う
+    if (!SENSOR_OIL_TEMP_PRESENT) {
+        // センサーが無い場合は常に 0 表示
         oilTempValue = 0.0f;
     }
 


### PR DESCRIPTION
## 日本語
油温センサーが199℃以上となった場合に"DE"が表示されず、0として扱われていた問題を解消しました。

## English
Fixed the issue where oil temperature readings over 199℃ were treated as zero instead of showing "DE".

------
https://chatgpt.com/codex/tasks/task_e_68728725661c83229d68e89dec9aeb5b