### PR TITLE
CI用ビルド環境の分離 / Separate CI build env

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,12 +1,18 @@
 ; PlatformIO Project Configuration File
 ;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
+;   ビルドオプション:  build flags, source filter
+;   アップロード設定:  custom upload port, speed and extra flags
+;   ライブラリ設定:    dependencies, extra library storages
+;   高度な設定:       extra scripting
 ;
-; Please visit documentation for the other options and examples
+; その他のオプションと例はドキュメントを参照
 ; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+; デフォルトビルド対象の環境
+default_envs = m5stack-cores3
+; CI用のテスト環境をデフォルトに
+test_default_envs = m5stack-cores3-ci
 
 [env:m5stack-cores3]
 platform = espressif32


### PR DESCRIPTION
## 概要 / Summary
- `platformio.ini` に `[platformio]` セクションを追加し、開発用とCI用のビルド環境を設定しました
- `default_envs` に `m5stack-cores3`、`test_default_envs` に `m5stack-cores3-ci` を指定
- これにより通常の `platformio run` と CI テスト時のビルドが分離されます

## English
- Added `[platformio]` section to `platformio.ini`
- `default_envs` now points to `m5stack-cores3` while `test_default_envs` uses `m5stack-cores3-ci`
- Prevents duplicate builds between development and CI

------
https://chatgpt.com/codex/tasks/task_e_6878d6148b2c8322a006ebfb00a64341