### PR TITLE
Disable unused M5 features / 使用しないM5機能を無効化

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -12,7 +12,7 @@ constexpr bool SENSOR_OIL_PRESSURE_PRESENT  = true;
 constexpr bool SENSOR_WATER_TEMP_PRESENT    = true;
 // 油温センサーを使用するかどうか
 constexpr bool SENSOR_OIL_TEMP_PRESENT      = true;
-constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
+constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = false; // ALS を無効化
 
 // ── 色設定 (16 bit) ──
 // RGB888 から 565 形式へ変換する constexpr 関数

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 
 #include <M5CoreS3.h>
 #include <Wire.h>
+#include <WiFi.h>  // WiFi 無効化用
 
 #include "modules/display.h"
 #include "modules/sensor.h"
@@ -22,6 +23,10 @@ void setup()
 
     M5.begin();
     CoreS3.begin(M5.config());
+
+    // WiFi を完全に停止
+    WiFi.mode(WIFI_OFF);
+    WiFi.disconnect(true);
 
     // 電源管理を初期化し、処理順序を明確にする
     M5.Power.begin();           // まず電源モジュールを初期化
@@ -45,8 +50,8 @@ void setup()
     M5.Lcd.clear();
     M5.Lcd.fillScreen(COLOR_BLACK);
 
-    M5.Speaker.begin();
-    M5.Imu.begin();
+    // M5.Speaker.begin();  // スピーカーを使用しないため無効化
+    // M5.Imu.begin();      // IMU を使用しないため無効化
     btStop();
 
     pinMode(9, INPUT_PULLUP);


### PR DESCRIPTION
## Summary / 概要
- WiFi の完全停止処理を追加
- スピーカーと IMU 初期化をコメントアウト
- ALS を使わない設定に変更

## Testing / テスト
- `pio test` (failed: network access)
- `pio run -e m5stack-cores3-ci` (failed: network access)


------
https://chatgpt.com/codex/tasks/task_e_6878e17c4ef48322a785327a17f67dcd