### PR TITLE
デバッグ用シリアル出力を追加 / Add serial debug output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,16 @@
 unsigned long lastFpsSecond = 0;  // 直近1秒判定用
 int fpsFrameCounter = 0;
 int currentFps = 0;
+unsigned long lastDebugPrint = 0;  // デバッグ表示用タイマー
+
+// ────────────────────── デバッグ情報表示 ──────────────────────
+static void printSensorDebugInfo()
+{
+  float pressure = calculateAverage(oilPressureSamples);
+  float water = calculateAverage(waterTemperatureSamples);
+  float oil = calculateAverage(oilTemperatureSamples);
+  Serial.printf("Oil.P: %.2f bar, Water.T: %.1f C, Oil.T: %.1f C\n", pressure, water, oil);
+}
 
 // ────────────────────── setup() ──────────────────────
 void setup()
@@ -90,8 +100,18 @@ void loop()
   if (now - lastFpsSecond >= FPS_INTERVAL_MS)
   {
     currentFps = fpsFrameCounter;
-    if (DEBUG_MODE_ENABLED) Serial.printf("FPS:%d\n", currentFps);
+    if (DEBUG_MODE_ENABLED)
+    {
+      Serial.printf("FPS:%d\n", currentFps);
+    }
     fpsFrameCounter = 0;
     lastFpsSecond = now;
+  }
+
+  if (DEBUG_MODE_ENABLED && now - lastDebugPrint >= 1000UL)
+  {
+    // FPS更新とは別に1秒ごとにデータを出力
+    printSensorDebugInfo();
+    lastDebugPrint = now;
   }
 }

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -109,12 +109,10 @@ void acquireSensorData()
     int16_t rawAdc = readAdcWithSettling(ADC_CH_OIL_PRESSURE);  // CH1: 油圧
     float pressureValue = convertVoltageToOilPressure(convertAdcToVoltage(rawAdc));
     oilPressureSamples[oilPressureIndex] = pressureValue;
-    Serial.printf("Oil Pressure: %.2f bar\n", pressureValue);
   }
   else
   {
     oilPressureSamples[oilPressureIndex] = 0.0f;
-    Serial.println("Oil Pressure: 0.00 bar");
   }
   oilPressureIndex = (oilPressureIndex + 1) % PRESSURE_SAMPLE_SIZE;
 


### PR DESCRIPTION
## 概要 / Summary
- DEBUG_MODE_ENABLED 時に油圧・水温・油温をまとめてシリアル表示する関数を追加
- FPS 出力とは別に1秒毎にセンサー値を表示
- 既存の個別シリアル出力を削除

## 変更内容 / Details
- `printSensorDebugInfo()` を `main.cpp` に新設
- ループ処理内でタイマーを使って情報を出力
- `sensor.cpp` のデバッグプリントを整理



------
https://chatgpt.com/codex/tasks/task_e_687dd3fa7ef88322b57c9940be2427e4