### PR TITLE
起動時の油圧メーターアニメーション修正 / Fix startup oil pressure animation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,9 @@ void setup()
     CoreS3.Ltr553.begin(&ltr553Params);
     CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
   }
+
+  // 起動時に油圧メーターを煽るアニメーションを実行
+  runStartupPressureSweep();
 }
 
 // ────────────────────── loop() ──────────────────────

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -1,10 +1,12 @@
 #include "display.h"
-#include "fps_display.h"
-#include "DrawFillArcMeter.h"
+
 #include <algorithm>
 #include <cmath>
-#include <limits>
 #include <cstdio>
+#include <limits>
+
+#include "DrawFillArcMeter.h"
+#include "fps_display.h"
 
 // ────────────────────── グローバル変数 ──────────────────────
 M5GFX display;
@@ -21,15 +23,14 @@ int recordedMaxOilTempTop = 0;
 static float prevPressureValue = std::numeric_limits<float>::quiet_NaN();
 static float prevWaterTempValue = std::numeric_limits<float>::quiet_NaN();
 
-struct DisplayCache {
+struct DisplayCache
+{
   float pressureAvg;
   float waterTempAvg;
   float oilTemp;
   int16_t maxOilTemp;
-} displayCache = {std::numeric_limits<float>::quiet_NaN(),
-                std::numeric_limits<float>::quiet_NaN(),
-                std::numeric_limits<float>::quiet_NaN(),
-                INT16_MIN};
+} displayCache = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
+                  std::numeric_limits<float>::quiet_NaN(), INT16_MIN};
 
 // ────────────────────── 油温バー描画 ──────────────────────
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
@@ -44,15 +45,17 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
   canvas.fillRect(X + 1, Y + 1, W - 2, H - 2, 0x18E3);
 
   float drawTemp = oilTemp;
-  if (drawTemp >= 199.0f) {
-      // 異常値の場合はバーを 0 として扱う
-      drawTemp = 0.0f;
+  if (drawTemp >= 199.0f)
+  {
+    // 異常値の場合はバーを 0 として扱う
+    drawTemp = 0.0f;
   }
 
-  if (drawTemp >= MIN_TEMP) {
-      int barWidth = static_cast<int>(W * (drawTemp - MIN_TEMP) / RANGE);
-      uint16_t barColor = (drawTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
-      canvas.fillRect(X, Y, barWidth, H, barColor);
+  if (drawTemp >= MIN_TEMP)
+  {
+    int barWidth = static_cast<int>(W * (drawTemp - MIN_TEMP) / RANGE);
+    uint16_t barColor = (drawTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
+    canvas.fillRect(X, Y, barWidth, H, barColor);
   }
 
   const int marks[] = {80, 90, 100, 110, 120, 130};
@@ -60,91 +63,90 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
   canvas.setTextColor(COLOR_WHITE);
   canvas.setFont(&fonts::Font0);
 
-  for (int m : marks) {
-      int tx = X + static_cast<int>(W * (m - MIN_TEMP) / RANGE);
-      canvas.drawPixel(tx, Y - 2, COLOR_WHITE);
-      canvas.setCursor(tx - 10, Y - 14);
-      canvas.printf("%d", m);
-      if (m == ALERT_TEMP)
-          canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
+  for (int m : marks)
+  {
+    int tx = X + static_cast<int>(W * (m - MIN_TEMP) / RANGE);
+    canvas.drawPixel(tx, Y - 2, COLOR_WHITE);
+    canvas.setCursor(tx - 10, Y - 14);
+    canvas.printf("%d", m);
+    if (m == ALERT_TEMP) canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
   }
 
   canvas.setCursor(X, Y + H + 4);
   canvas.printf("OIL.T / Celsius,  MAX:%03d", maxOilTemp);
   // snprintf でバッファサイズを指定し、
   // 安全に文字列化する
-  if (oilTemp >= 199.0f) {
-      // 199℃以上は "Disconnection" と "Error" を小さなフォントで表示
-      canvas.setFont(&fonts::Font0);
-      canvas.drawRightString("Disconnection", LCD_WIDTH - 1, 2);
-      canvas.drawRightString("Error", LCD_WIDTH - 1, 2 + canvas.fontHeight());
-  } else {
-      char tempStr[8];
-      snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
-      canvas.setFont(&FreeSansBold24pt7b);
-      canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
+  if (oilTemp >= 199.0f)
+  {
+    // 199℃以上は "Disconnection" と "Error" を小さなフォントで表示
+    canvas.setFont(&fonts::Font0);
+    canvas.drawRightString("Disconnection", LCD_WIDTH - 1, 2);
+    canvas.drawRightString("Error", LCD_WIDTH - 1, 2 + canvas.fontHeight());
+  }
+  else
+  {
+    char tempStr[8];
+    snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
+    canvas.setFont(&FreeSansBold24pt7b);
+    canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
   }
 }
 
 // ────────────────────── 画面更新＋ログ ──────────────────────
-void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
-                       float oilTemp, int16_t maxOilTemp)
+void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp)
 {
   const int TOPBAR_Y = 0, TOPBAR_H = 50;
   const int GAUGE_H = 170;
 
   // 温度は0.1度以上、油圧は0.05以上変化したら更新する
-  bool oilChanged = std::isnan(displayCache.oilTemp) ||
-                    fabs(oilTemp - displayCache.oilTemp) >= 0.1f ||
+  bool oilChanged = std::isnan(displayCache.oilTemp) || fabs(oilTemp - displayCache.oilTemp) >= 0.1f ||
                     (maxOilTemp != displayCache.maxOilTemp);
-  bool pressureChanged = std::isnan(displayCache.pressureAvg) ||
-                         fabs(pressureAvg - displayCache.pressureAvg) >= 0.05f;
-  bool waterChanged = std::isnan(displayCache.waterTempAvg) ||
-                     fabs(waterTempAvg - displayCache.waterTempAvg) >= 0.1f;
+  bool pressureChanged = std::isnan(displayCache.pressureAvg) || fabs(pressureAvg - displayCache.pressureAvg) >= 0.05f;
+  bool waterChanged = std::isnan(displayCache.waterTempAvg) || fabs(waterTempAvg - displayCache.waterTempAvg) >= 0.1f;
 
   mainCanvas.setTextColor(COLOR_WHITE);
 
-  if (oilChanged) {
-      mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
-      if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
-      drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
-      displayCache.oilTemp = oilTemp;
-      displayCache.maxOilTemp = maxOilTemp;
+  if (oilChanged)
+  {
+    mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
+    if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
+    drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
+    displayCache.oilTemp = oilTemp;
+    displayCache.maxOilTemp = maxOilTemp;
   }
 
-  if (pressureChanged || !pressureGaugeInitialized) {
-      if (!pressureGaugeInitialized) {
-          mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
-      }
-      bool useDecimal = pressureAvg < 9.95f;
-      drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_METER,  8.0f,
-                       COLOR_RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                       prevPressureValue,
-                       0.5f, useDecimal,   0,   60,
-                       !pressureGaugeInitialized);
-      pressureGaugeInitialized = true;
-      displayCache.pressureAvg = pressureAvg;
+  if (pressureChanged || !pressureGaugeInitialized)
+  {
+    if (!pressureGaugeInitialized)
+    {
+      mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+    }
+    bool useDecimal = pressureAvg < 9.95f;
+    drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "BAR", "OIL.P",
+                     recordedMaxOilPressure, prevPressureValue, 0.5f, useDecimal, 0, 60, !pressureGaugeInitialized);
+    pressureGaugeInitialized = true;
+    displayCache.pressureAvg = pressureAvg;
   }
 
-  if (waterChanged || !waterGaugeInitialized) {
-      if (!waterGaugeInitialized) {
-          mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
-      }
-      drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f,
-                       COLOR_RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                       prevWaterTempValue,
-                       1.0f, false, 160,  60,
-                       !waterGaugeInitialized,
-                       5.0f, WATER_TEMP_METER_MIN);
-      waterGaugeInitialized = true;
-      displayCache.waterTempAvg = waterTempAvg;
+  if (waterChanged || !waterGaugeInitialized)
+  {
+    if (!waterGaugeInitialized)
+    {
+      mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+    }
+    drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f, COLOR_RED, "Celsius",
+                     "WATER.T", recordedMaxWaterTemp, prevWaterTempValue, 1.0f, false, 160, 60, !waterGaugeInitialized,
+                     5.0f, WATER_TEMP_METER_MIN);
+    waterGaugeInitialized = true;
+    displayCache.waterTempAvg = waterTempAvg;
   }
 
   bool fpsChanged = drawFpsOverlay();
 
   // 値が更新されたときのみスプライトを転送する
-  if (oilChanged || pressureChanged || waterChanged || fpsChanged) {
-      mainCanvas.pushSprite(0, 0);
+  if (oilChanged || pressureChanged || waterChanged || fpsChanged)
+  {
+    mainCanvas.pushSprite(0, 0);
   }
 }
 
@@ -166,23 +168,61 @@ void updateGauges()
 
   smoothWaterTemp += 0.1f * (targetWaterTemp - smoothWaterTemp);
   smoothOilTemp += 0.1f * (targetOilTemp - smoothOilTemp);
-  smoothOilPressure +=
-      OIL_PRESSURE_SMOOTHING_ALPHA * (pressureAvg - smoothOilPressure);
+  smoothOilPressure += OIL_PRESSURE_SMOOTHING_ALPHA * (pressureAvg - smoothOilPressure);
 
   float oilTempValue = smoothOilTemp;
   float pressureValue = smoothOilPressure;
-  if (!SENSOR_OIL_TEMP_PRESENT) {
-      // センサーが無い場合は常に 0 表示
-      oilTempValue = 0.0f;
+  if (!SENSOR_OIL_TEMP_PRESENT)
+  {
+    // センサーが無い場合は常に 0 表示
+    oilTempValue = 0.0f;
   }
 
-  recordedMaxOilPressure =
-      std::max(recordedMaxOilPressure, pressureAvg);
+  recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
   recordedMaxWaterTemp = std::max(recordedMaxWaterTemp, smoothWaterTemp);
-  if (targetOilTemp < 199.0f) {
-      recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
+  if (targetOilTemp < 199.0f)
+  {
+    recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
   }
 
-  renderDisplayAndLog(pressureValue, smoothWaterTemp,
-                      oilTempValue, recordedMaxOilTempTop);
+  renderDisplayAndLog(pressureValue, smoothWaterTemp, oilTempValue, recordedMaxOilTempTop);
+}
+
+// ────────────────────── 起動アニメーション ──────────────────────
+void runStartupPressureSweep()
+{
+  float dummyMax = 0.0f;
+  float localPrev = std::numeric_limits<float>::quiet_NaN();
+
+  // 背景を初期化してメーターを描画
+  mainCanvas.fillRect(0, 60, 160, 170, COLOR_BLACK);
+  drawFillArcMeter(mainCanvas, 0.0f, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "BAR", "OIL.P", dummyMax, localPrev,
+                   0.5f, true, 0, 60, true);
+  mainCanvas.pushSprite(0, 0);
+
+  constexpr float STEP = 0.5f;
+  constexpr int CYCLES = 3;
+
+  for (int c = 0; c < CYCLES; ++c)
+  {
+    for (float v = 0.0f; v <= 8.0f; v += STEP)
+    {
+      drawFillArcMeter(mainCanvas, v, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "BAR", "OIL.P", dummyMax, localPrev,
+                       0.5f, v < 9.95f, 0, 60, false);
+      mainCanvas.pushSprite(0, 0);
+      delay(40);
+    }
+
+    for (float v = 8.0f; v >= 0.0f; v -= STEP)
+    {
+      drawFillArcMeter(mainCanvas, v, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "BAR", "OIL.P", dummyMax, localPrev,
+                       0.5f, v < 9.95f, 0, 60, false);
+      mainCanvas.pushSprite(0, 0);
+      delay(40);
+    }
+  }
+
+  // 次回更新時に再描画するよう初期化
+  pressureGaugeInitialized = false;
+  prevPressureValue = std::numeric_limits<float>::quiet_NaN();
 }

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -2,6 +2,7 @@
 #define DISPLAY_H
 
 #include <M5GFX.h>
+
 #include "config.h"
 #include "sensor.h"
 
@@ -10,8 +11,9 @@ extern M5Canvas mainCanvas;
 extern int currentFps;
 
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp);
-void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
-                       float oilTemp, int16_t maxOilTemp);
+void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp);
 void updateGauges();
+// 起動時の油圧メーターアニメーション
+void runStartupPressureSweep();
 
-#endif // DISPLAY_H
+#endif  // DISPLAY_H


### PR DESCRIPTION
## Summary / 概要
- `runStartupPressureSweep` 内の `drawFillArcMeter` 呼び出しで不足していた引数を追加
- clang-format と clang-tidy を実行（clang-tidy は多数の警告で失敗）

## Testing / テスト
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -- -Iinclude` (エラー多数)


------
https://chatgpt.com/codex/tasks/task_e_687dd962b868832280cbd2ad95d4d4f6