### PR TITLE
Add voltage drop correction factor / 電圧降下補正係数を追加

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -14,6 +14,10 @@ constexpr bool SENSOR_WATER_TEMP_PRESENT = true;
 constexpr bool SENSOR_OIL_TEMP_PRESENT = true;
 constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = false;  // ALS を無効化
 
+// ── 電圧降下補正 ──
+// 0.3sq ケーブル往復14mで約0.137Vの降下を想定
+constexpr float VOLTAGE_DROP = 0.137f;
+
 // ── 色設定 (16 bit) ──
 // RGB888 から 565 形式へ変換する constexpr 関数
 constexpr uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b)

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -29,8 +29,7 @@ constexpr uint16_t TEMP_SAMPLE_INTERVAL_MS = 500;
 
 // ────────────────────── 変換定数 ──────────────────────
 constexpr float SUPPLY_VOLTAGE = 5.0f;
-// 0.3sq ケーブル往復14mで生じる約0.137Vの降下を補正
-constexpr float VOLTAGE_DROP = 0.137f;
+// 電圧降下は config で設定
 constexpr float CORRECTION_FACTOR = SUPPLY_VOLTAGE / (SUPPLY_VOLTAGE - VOLTAGE_DROP);
 constexpr float THERMISTOR_R25 = 10000.0f;
 constexpr float THERMISTOR_B_CONSTANT = 3380.0f;

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -29,7 +29,7 @@ constexpr uint16_t TEMP_SAMPLE_INTERVAL_MS = 500;
 
 // ────────────────────── 変換定数 ──────────────────────
 constexpr float SUPPLY_VOLTAGE = 5.0f;
-// 配線による電圧降下を補正する係数
+// 0.3sq ケーブル往復14mで生じる約0.137Vの降下を補正
 constexpr float VOLTAGE_DROP = 0.137f;
 constexpr float CORRECTION_FACTOR = SUPPLY_VOLTAGE / (SUPPLY_VOLTAGE - VOLTAGE_DROP);
 constexpr float THERMISTOR_R25 = 10000.0f;

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -29,6 +29,9 @@ constexpr uint16_t TEMP_SAMPLE_INTERVAL_MS = 500;
 
 // ────────────────────── 変換定数 ──────────────────────
 constexpr float SUPPLY_VOLTAGE = 5.0f;
+// 配線による電圧降下を補正する係数
+constexpr float VOLTAGE_DROP = 0.137f;
+constexpr float CORRECTION_FACTOR = SUPPLY_VOLTAGE / (SUPPLY_VOLTAGE - VOLTAGE_DROP);
 constexpr float THERMISTOR_R25 = 10000.0f;
 constexpr float THERMISTOR_B_CONSTANT = 3380.0f;
 constexpr float ABSOLUTE_TEMPERATURE_25 = 298.16f;  // 273.16 + 25
@@ -39,6 +42,7 @@ static float convertAdcToVoltage(int16_t rawAdc) { return (rawAdc * 6.144f) / 20
 
 static float convertVoltageToOilPressure(float voltage)
 {
+  voltage *= CORRECTION_FACTOR;
   // 電源電圧近くまで上昇してもそのまま変換し、
   // 12bar 以上かどうかは呼び出し側で判断する
 
@@ -48,6 +52,7 @@ static float convertVoltageToOilPressure(float voltage)
 
 static float convertVoltageToTemp(float voltage)
 {
+  voltage *= CORRECTION_FACTOR;
   // 電源電圧より高い/等しい電圧は異常値として捨てる
   if (voltage <= 0.0f || voltage >= SUPPLY_VOLTAGE) return 200.0f;
 

--- a/test/test_sensor_conversion.cpp
+++ b/test/test_sensor_conversion.cpp
@@ -15,8 +15,8 @@ void test_convert_adc_to_voltage()
 void test_convert_voltage_to_oil_pressure()
 {
   float result = convertVoltageToOilPressure(1.0f);
-  // 1.0V は約1.25barになる
-  TEST_ASSERT_FLOAT_WITHIN(0.01f, 1.25f, result);
+  // 電圧降下補正後は約1.32barになる
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 1.32f, result);
 
   result = convertVoltageToOilPressure(0.25f);
   // 0.5V 未満は0として扱う
@@ -27,12 +27,12 @@ void test_convert_voltage_to_oil_pressure()
 void test_convert_voltage_to_temp()
 {
   float result = convertVoltageToTemp(2.5f);
-  // 2.5V は約25℃になる
-  TEST_ASSERT_FLOAT_WITHIN(0.1f, 25.0f, result);
+  // 電圧降下補正後は約23.5℃になる
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 23.5f, result);
 
   result = convertVoltageToTemp(1.0f);
-  // 1.0V は約66.5℃になる
-  TEST_ASSERT_FLOAT_WITHIN(0.1f, 66.54f, result);
+  // 1.0V は約65.4℃になる
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 65.36f, result);
 }
 
 // 平均計算のテスト


### PR DESCRIPTION
## Summary
- account for voltage drop on 0.3sq cable by introducing `CORRECTION_FACTOR`
- update sensor conversion functions
- adjust unit tests for corrected results

## Testing
- `clang-format -i src/modules/sensor.cpp test/test_sensor_conversion.cpp`
- `clang-tidy src/modules/sensor.cpp test/test_sensor_conversion.cpp -- -Iinclude` *(fails: warnings treated as errors)*
- `platformio test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_687ef2023a3c8322b2beb54278e328aa