### PR TITLE
Fix: oil pressure smoothing below 0.1 bar / 油圧0.1未満の平滑化修正

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -36,6 +36,8 @@ constexpr int DISPLAY_COLOR_DEPTH = 16;
 constexpr float MAX_OIL_PRESSURE_DISPLAY = 15.0f;
 // メーター目盛の上限
 constexpr float MAX_OIL_PRESSURE_METER = 10.0f;
+// 0.1bar 未満は0として表示する
+constexpr float MIN_OIL_PRESSURE_DISPLAY = 0.1f;
 // 0.25bar 以下なら接続エラーとして扱う閾値
 constexpr float OIL_PRESSURE_DISCONNECT_THRESHOLD = 0.25f;
 // 油圧の平滑化係数

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -1,10 +1,12 @@
 #include "display.h"
-#include "fps_display.h"
-#include "DrawFillArcMeter.h"
+
 #include <algorithm>
 #include <cmath>
-#include <limits>
 #include <cstdio>
+#include <limits>
+
+#include "DrawFillArcMeter.h"
+#include "fps_display.h"
 
 // ────────────────────── グローバル変数 ──────────────────────
 M5GFX display;
@@ -21,15 +23,14 @@ int recordedMaxOilTempTop = 0;
 static float prevPressureValue = std::numeric_limits<float>::quiet_NaN();
 static float prevWaterTempValue = std::numeric_limits<float>::quiet_NaN();
 
-struct DisplayCache {
+struct DisplayCache
+{
   float pressureAvg;
   float waterTempAvg;
   float oilTemp;
   int16_t maxOilTemp;
-} displayCache = {std::numeric_limits<float>::quiet_NaN(),
-                std::numeric_limits<float>::quiet_NaN(),
-                std::numeric_limits<float>::quiet_NaN(),
-                INT16_MIN};
+} displayCache = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
+                  std::numeric_limits<float>::quiet_NaN(), INT16_MIN};
 
 // ────────────────────── 油温バー描画 ──────────────────────
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
@@ -44,15 +45,17 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
   canvas.fillRect(X + 1, Y + 1, W - 2, H - 2, 0x18E3);
 
   float drawTemp = oilTemp;
-  if (drawTemp >= 199.0f) {
-      // 異常値の場合はバーを 0 として扱う
-      drawTemp = 0.0f;
+  if (drawTemp >= 199.0f)
+  {
+    // 異常値の場合はバーを 0 として扱う
+    drawTemp = 0.0f;
   }
 
-  if (drawTemp >= MIN_TEMP) {
-      int barWidth = static_cast<int>(W * (drawTemp - MIN_TEMP) / RANGE);
-      uint16_t barColor = (drawTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
-      canvas.fillRect(X, Y, barWidth, H, barColor);
+  if (drawTemp >= MIN_TEMP)
+  {
+    int barWidth = static_cast<int>(W * (drawTemp - MIN_TEMP) / RANGE);
+    uint16_t barColor = (drawTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
+    canvas.fillRect(X, Y, barWidth, H, barColor);
   }
 
   const int marks[] = {80, 90, 100, 110, 120, 130};
@@ -60,91 +63,90 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
   canvas.setTextColor(COLOR_WHITE);
   canvas.setFont(&fonts::Font0);
 
-  for (int m : marks) {
-      int tx = X + static_cast<int>(W * (m - MIN_TEMP) / RANGE);
-      canvas.drawPixel(tx, Y - 2, COLOR_WHITE);
-      canvas.setCursor(tx - 10, Y - 14);
-      canvas.printf("%d", m);
-      if (m == ALERT_TEMP)
-          canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
+  for (int m : marks)
+  {
+    int tx = X + static_cast<int>(W * (m - MIN_TEMP) / RANGE);
+    canvas.drawPixel(tx, Y - 2, COLOR_WHITE);
+    canvas.setCursor(tx - 10, Y - 14);
+    canvas.printf("%d", m);
+    if (m == ALERT_TEMP) canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
   }
 
   canvas.setCursor(X, Y + H + 4);
   canvas.printf("OIL.T / Celsius,  MAX:%03d", maxOilTemp);
   // snprintf でバッファサイズを指定し、
   // 安全に文字列化する
-  if (oilTemp >= 199.0f) {
-      // 199℃以上は "Disconnection" と "Error" を小さなフォントで表示
-      canvas.setFont(&fonts::Font0);
-      canvas.drawRightString("Disconnection", LCD_WIDTH - 1, 2);
-      canvas.drawRightString("Error", LCD_WIDTH - 1, 2 + canvas.fontHeight());
-  } else {
-      char tempStr[8];
-      snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
-      canvas.setFont(&FreeSansBold24pt7b);
-      canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
+  if (oilTemp >= 199.0f)
+  {
+    // 199℃以上は "Disconnection" と "Error" を小さなフォントで表示
+    canvas.setFont(&fonts::Font0);
+    canvas.drawRightString("Disconnection", LCD_WIDTH - 1, 2);
+    canvas.drawRightString("Error", LCD_WIDTH - 1, 2 + canvas.fontHeight());
+  }
+  else
+  {
+    char tempStr[8];
+    snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
+    canvas.setFont(&FreeSansBold24pt7b);
+    canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
   }
 }
 
 // ────────────────────── 画面更新＋ログ ──────────────────────
-void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
-                       float oilTemp, int16_t maxOilTemp)
+void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp)
 {
   const int TOPBAR_Y = 0, TOPBAR_H = 50;
   const int GAUGE_H = 170;
 
   // 温度は0.1度以上、油圧は0.05以上変化したら更新する
-  bool oilChanged = std::isnan(displayCache.oilTemp) ||
-                    fabs(oilTemp - displayCache.oilTemp) >= 0.1f ||
+  bool oilChanged = std::isnan(displayCache.oilTemp) || fabs(oilTemp - displayCache.oilTemp) >= 0.1f ||
                     (maxOilTemp != displayCache.maxOilTemp);
-  bool pressureChanged = std::isnan(displayCache.pressureAvg) ||
-                         fabs(pressureAvg - displayCache.pressureAvg) >= 0.05f;
-  bool waterChanged = std::isnan(displayCache.waterTempAvg) ||
-                     fabs(waterTempAvg - displayCache.waterTempAvg) >= 0.1f;
+  bool pressureChanged = std::isnan(displayCache.pressureAvg) || fabs(pressureAvg - displayCache.pressureAvg) >= 0.05f;
+  bool waterChanged = std::isnan(displayCache.waterTempAvg) || fabs(waterTempAvg - displayCache.waterTempAvg) >= 0.1f;
 
   mainCanvas.setTextColor(COLOR_WHITE);
 
-  if (oilChanged) {
-      mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
-      if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
-      drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
-      displayCache.oilTemp = oilTemp;
-      displayCache.maxOilTemp = maxOilTemp;
+  if (oilChanged)
+  {
+    mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
+    if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
+    drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
+    displayCache.oilTemp = oilTemp;
+    displayCache.maxOilTemp = maxOilTemp;
   }
 
-  if (pressureChanged || !pressureGaugeInitialized) {
-      if (!pressureGaugeInitialized) {
-          mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
-      }
-      bool useDecimal = pressureAvg < 9.95f;
-      drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_METER,  8.0f,
-                       COLOR_RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                       prevPressureValue,
-                       0.5f, useDecimal,   0,   60,
-                       !pressureGaugeInitialized);
-      pressureGaugeInitialized = true;
-      displayCache.pressureAvg = pressureAvg;
+  if (pressureChanged || !pressureGaugeInitialized)
+  {
+    if (!pressureGaugeInitialized)
+    {
+      mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+    }
+    bool useDecimal = pressureAvg < 9.95f;
+    drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "BAR", "OIL.P",
+                     recordedMaxOilPressure, prevPressureValue, 0.5f, useDecimal, 0, 60, !pressureGaugeInitialized);
+    pressureGaugeInitialized = true;
+    displayCache.pressureAvg = pressureAvg;
   }
 
-  if (waterChanged || !waterGaugeInitialized) {
-      if (!waterGaugeInitialized) {
-          mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
-      }
-      drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f,
-                       COLOR_RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                       prevWaterTempValue,
-                       1.0f, false, 160,  60,
-                       !waterGaugeInitialized,
-                       5.0f, WATER_TEMP_METER_MIN);
-      waterGaugeInitialized = true;
-      displayCache.waterTempAvg = waterTempAvg;
+  if (waterChanged || !waterGaugeInitialized)
+  {
+    if (!waterGaugeInitialized)
+    {
+      mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+    }
+    drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f, COLOR_RED, "Celsius",
+                     "WATER.T", recordedMaxWaterTemp, prevWaterTempValue, 1.0f, false, 160, 60, !waterGaugeInitialized,
+                     5.0f, WATER_TEMP_METER_MIN);
+    waterGaugeInitialized = true;
+    displayCache.waterTempAvg = waterTempAvg;
   }
 
   bool fpsChanged = drawFpsOverlay();
 
   // 値が更新されたときのみスプライトを転送する
-  if (oilChanged || pressureChanged || waterChanged || fpsChanged) {
-      mainCanvas.pushSprite(0, 0);
+  if (oilChanged || pressureChanged || waterChanged || fpsChanged)
+  {
+    mainCanvas.pushSprite(0, 0);
   }
 }
 
@@ -166,23 +168,35 @@ void updateGauges()
 
   smoothWaterTemp += 0.1f * (targetWaterTemp - smoothWaterTemp);
   smoothOilTemp += 0.1f * (targetOilTemp - smoothOilTemp);
-  smoothOilPressure +=
-      OIL_PRESSURE_SMOOTHING_ALPHA * (pressureAvg - smoothOilPressure);
+  if (pressureAvg <= MIN_OIL_PRESSURE_DISPLAY)
+  {
+    // 0.1bar 以下なら滑らかさより即座に 0 に戻す
+    smoothOilPressure = 0.0f;
+  }
+  else
+  {
+    smoothOilPressure += OIL_PRESSURE_SMOOTHING_ALPHA * (pressureAvg - smoothOilPressure);
+  }
 
   float oilTempValue = smoothOilTemp;
   float pressureValue = smoothOilPressure;
-  if (!SENSOR_OIL_TEMP_PRESENT) {
-      // センサーが無い場合は常に 0 表示
-      oilTempValue = 0.0f;
+  if (pressureValue <= MIN_OIL_PRESSURE_DISPLAY)
+  {
+    // 0.1bar 以下は 0 として表示
+    pressureValue = 0.0f;
+  }
+  if (!SENSOR_OIL_TEMP_PRESENT)
+  {
+    // センサーが無い場合は常に 0 表示
+    oilTempValue = 0.0f;
   }
 
-  recordedMaxOilPressure =
-      std::max(recordedMaxOilPressure, pressureAvg);
+  recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
   recordedMaxWaterTemp = std::max(recordedMaxWaterTemp, smoothWaterTemp);
-  if (targetOilTemp < 199.0f) {
-      recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
+  if (targetOilTemp < 199.0f)
+  {
+    recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
   }
 
-  renderDisplayAndLog(pressureValue, smoothWaterTemp,
-                      oilTempValue, recordedMaxOilTempTop);
+  renderDisplayAndLog(pressureValue, smoothWaterTemp, oilTempValue, recordedMaxOilTempTop);
 }


### PR DESCRIPTION
## Summary / 概要
- keep constant `MIN_OIL_PRESSURE_DISPLAY` at 0.1 bar
- update smoothing logic so values at or below 0.1 bar drop instantly to zero
- use `<=` check when clamping pressure

## Testing
- `clang-format -i include/config.h src/modules/display.cpp`
- `clang-tidy include/config.h src/modules/display.cpp -- -Iinclude` *(fails: M5CoreS3.h not found)*
- `pio test` *(fails due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_687f0caa45388322af37935cf1b1b112