### PR TITLE
Add oil pressure gauge range/油圧ゲージ範囲の追加

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -41,6 +41,8 @@ constexpr int DISPLAY_COLOR_DEPTH = 16;
 // ── 油圧の表示設定 ──
 // 数値表示の上限 (バー単位)
 constexpr float MAX_OIL_PRESSURE_DISPLAY = 15.0f;
+// メーター目盛の下限
+constexpr float MIN_OIL_PRESSURE_METER = 4.0f;
 // メーター目盛の上限
 constexpr float MAX_OIL_PRESSURE_METER = 10.0f;
 // 0.25bar 以下なら接続エラーとして扱う閾値

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -126,8 +126,9 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
       mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
     }
     bool useDecimal = pressureAvg < 9.95F;
-    drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "x100kPa", "OIL.P",
-                     recordedMaxOilPressure, prevPressureValue, 0.5f, useDecimal, 0, 60, !pressureGaugeInitialized);
+    drawFillArcMeter(mainCanvas, pressureAvg, MIN_OIL_PRESSURE_METER, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "x100kPa",
+                     "OIL.P", recordedMaxOilPressure, prevPressureValue, 0.5f, useDecimal, 0, 60,
+                     !pressureGaugeInitialized);
     pressureGaugeInitialized = true;
     displayCache.pressureAvg = pressureAvg;
   }


### PR DESCRIPTION
## Summary / 概要
- set oil pressure gauge to show marks from 4 to 10
- update display to use the new constant

## Testing / テスト
- `clang-format -i include/config.h src/modules/display.cpp`
- `clang-tidy include/config.h src/modules/display.cpp -- -Iinclude` (fails: no compile database)
- `platformio run` *(failed: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_688254d3f7148322b1ef54abf2a0e772