### PR TITLE
Disable debug mode / デバッグモードを無効化

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -5,7 +5,7 @@
 
 // ────────────────────── 設定 ──────────────────────
 // デバッグ用メッセージ表示の有無
-constexpr bool DEBUG_MODE_ENABLED = true;
+constexpr bool DEBUG_MODE_ENABLED = false;
 
 // デモモードを有効にするかどうか
 constexpr bool DEMO_MODE_ENABLED = false;


### PR DESCRIPTION
## Summary / 概要
- Set `DEBUG_MODE_ENABLED` to false for production use
- `clang-tidy` failed due to missing headers
- PlatformIO tests could not run because required downloads were blocked

## Testing
- `clang-format -i include/config.h src/main.cpp src/modules/sensor.cpp`
- `clang-tidy src/main.cpp -- -std=c++17` *(failed: 'M5CoreS3.h' not found)*
- `platformio test` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6882461f6fb8832281a949cbdbf70ae4