### PR TITLE
Fix initial gauge display / 初回バー表示修正

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -50,7 +50,8 @@ void drawFillArcMeter(M5Canvas /*unused*/ &canvas, float value, float minValue, 
   if (drawStatic || std::isnan(previousValue))
   {
     canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, 0, INACTIVE_COLOR);
-    previousValue = clampedValue;
+    // 初期化時は前回値を更新せず、
+    // 後続の更新処理で必ずバーを描画する
   }
 
   if (drawStatic)


### PR DESCRIPTION
## Summary / 概要
- avoid skipping bar drawing on first frame
- 初期表示時にバーが欠ける問題を修正しました

## Testing / テスト
- `clang-format -i src/DrawFillArcMeter.h`
- `clang-tidy src/DrawFillArcMeter.h -- -Iinclude` *(fails: 'M5GFX.h' file not found)*
- `platformio test` *(failed: network restrictions prevented platform installation)*


------
https://chatgpt.com/codex/tasks/task_e_688534667fd8832283c879a84c7914cc