### PR TITLE
ゲージ初期化値をゼロに変更 / Initialize gauge values to zero

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -50,7 +50,9 @@ void drawFillArcMeter(M5Canvas /*unused*/ &canvas, float value, float minValue, 
   if (drawStatic || std::isnan(previousValue))
   {
     canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, 0, INACTIVE_COLOR);
-    previousValue = clampedValue;
+    // 初期値を0にして次の処理でバーを全描画
+    // 温度や油圧の初期表示を0とするため
+    previousValue = 0.0f;
   }
 
   if (drawStatic)


### PR DESCRIPTION
## Summary / 概要
- `drawFillArcMeter` の初期値を 0 に設定
- initialize gauges at zero value for all meters

## Testing / テスト
- `clang-format` を実行
- `clang-tidy` を実行 (依存ライブラリが無く失敗)
- `platformio test` を実行するも依存取得時にネットワーク制限で失敗

------
https://chatgpt.com/codex/tasks/task_e_6885958a488c8322a23e724f9820131e