### PR TITLE
Remove FPS label overlay / FPS表示のラベルを削除

### DIFF
--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -20,7 +20,7 @@ auto drawFpsOverlay() -> bool
   if (!fpsLabelDrawn)
   {
     // 数値表示用に領域を初期化
-    mainCanvas.fillRect(0, FPS_Y, 30, 16, COLOR_BLACK);
+    mainCanvas.fillRect(0, FPS_Y, 16, 16, COLOR_BLACK);
     fpsLabelDrawn = true;
     lastFpsDrawTime = 0;  // 初回はすぐ更新するため0に設定
   }

--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -19,10 +19,8 @@ auto drawFpsOverlay() -> bool
   unsigned long now = millis();
   if (!fpsLabelDrawn)
   {
-    // 表示領域を初期化してラベルを描画
-    mainCanvas.fillRect(0, FPS_Y, 20, 16, COLOR_BLACK);
-    mainCanvas.setCursor(5, FPS_Y);
-    mainCanvas.println("FPS:");
+    // 数字のみ描画するため領域を初期化
+    mainCanvas.fillRect(0, FPS_Y, 35, 16, COLOR_BLACK);
     fpsLabelDrawn = true;
     lastFpsDrawTime = 0;  // 初回はすぐ更新するため0に設定
   }

--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -19,8 +19,8 @@ auto drawFpsOverlay() -> bool
   unsigned long now = millis();
   if (!fpsLabelDrawn)
   {
-    // 数字のみ描画するため領域を初期化
-    mainCanvas.fillRect(0, FPS_Y, 35, 16, COLOR_BLACK);
+    // 数値表示用に領域を初期化
+    mainCanvas.fillRect(0, FPS_Y, 30, 16, COLOR_BLACK);
     fpsLabelDrawn = true;
     lastFpsDrawTime = 0;  // 初回はすぐ更新するため0に設定
   }
@@ -28,8 +28,8 @@ auto drawFpsOverlay() -> bool
   if (now - lastFpsDrawTime >= 1000UL)
   {
     // 数値表示部のみ塗り直して更新
-    mainCanvas.fillRect(5, FPS_Y + 8, 30, 8, COLOR_BLACK);
-    mainCanvas.setCursor(5, FPS_Y + 8);
+    mainCanvas.fillRect(0, FPS_Y + 8, 30, 8, COLOR_BLACK);
+    mainCanvas.setCursor(0, FPS_Y + 8);
     mainCanvas.printf("%d", currentFps);
     lastFpsDrawTime = now;
     return true;


### PR DESCRIPTION
## Summary / 概要
- remove the "FPS:" text from fps_display.cpp so only the number remains

## Testing / テスト
- `clang-format -i src/modules/fps_display.cpp`
- `clang-tidy src/modules/fps_display.cpp -- -Iinclude` *(fails: 'M5CoreS3.h' not found)*
- `platformio run -e m5stack-cores3` *(blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6885b96cfda083228fc0f398221e25f5