### PR TITLE
ショート回路エラー表示の削除 / Remove short circuit error display

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -193,15 +193,7 @@ void drawFillArcMeter(M5Canvas /*unused*/ &canvas, float value, float minValue, 
   char errorLine2[8];
   bool isErrorText = false;
   // 文字列比較は strcmp を使用する
-  if (strcmp(unit, "x100kPa") == 0 && value >= 11.0f)
-  {
-    // 12bar 以上のショートエラー表示
-    // "Short circuit\nError" を表示
-    snprintf(errorLine1, sizeof(errorLine1), "Short circuit");
-    snprintf(errorLine2, sizeof(errorLine2), "Error");
-    isErrorText = true;
-  }
-  else if (strcmp(unit, "Celsius") == 0 && value >= 199.0f)
+  if (strcmp(unit, "Celsius") == 0 && value >= 199.0f)
   {
     // 199℃以上は "Disconnection\nError" を表示
     snprintf(errorLine1, sizeof(errorLine1), "Disconnection");


### PR DESCRIPTION
## Summary / 概要
- ショート扱い処理を完全に削除
- `Celsius` のエラー表示ロジックのみ残す

## Testing / テスト
- `clang-format -i src/DrawFillArcMeter.h`
- `clang-tidy src/DrawFillArcMeter.h -- -Iinclude` *(fails: warnings treated as errors)*
- `pio run -e m5stack-cores3` *(failed: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6885bb52ebe083228f88359069ebbb29