### PR TITLE
Limit frame rate to 60FPS / 60FPS上限制御追加

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -79,6 +79,9 @@ constexpr int MEDIAN_BUFFER_SIZE = 10;
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;
 
+// 最大60FPSに制御するためのフレーム間隔 [us]
+constexpr unsigned long FRAME_INTERVAL_US = 1000000UL / 60;
+
 // ── ADS1015 のチャンネル定義 ──
 constexpr uint8_t ADC_CH_WATER_TEMP = 1;
 constexpr uint8_t ADC_CH_OIL_PRESSURE = 2;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,8 @@
 unsigned long lastFpsSecond = 0;  // 直近1秒判定用
 int fpsFrameCounter = 0;
 int currentFps = 0;
-unsigned long lastDebugPrint = 0;  // デバッグ表示用タイマー
+unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
+unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -85,6 +86,14 @@ void setup()
 void loop()
 {
   static unsigned long lastAlsMeasurementTime = 0;
+  unsigned long nowUs = micros();
+  // 前のフレームから16.6ms未満なら待機
+  if (lastFrameTimeUs != 0 && nowUs - lastFrameTimeUs < FRAME_INTERVAL_US)
+  {
+    delayMicroseconds(FRAME_INTERVAL_US - (nowUs - lastFrameTimeUs));
+    nowUs = micros();
+  }
+  lastFrameTimeUs = nowUs;
   unsigned long now = millis();
 
   if (now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)


### PR DESCRIPTION
## Summary / 概要
- add FRAME_INTERVAL_US constant
- limit main loop speed using delayMicroseconds

## Testing / テスト
- `clang-format -i include/config.h src/main.cpp`
- `clang-tidy include/config.h src/main.cpp -- -Iinclude` *(failed: M5CoreS3.h file not found)*
- `platformio test` *(failed: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_6885c3956ef08322acd08626d412526b