### PR TITLE
夜間輝度設定の再調整 / Readjust night brightness

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -72,7 +72,8 @@ constexpr uint8_t LUX_THRESHOLD_DUSK = 10;
 
 constexpr uint8_t BACKLIGHT_DAY = 255;
 constexpr uint8_t BACKLIGHT_DUSK = 200;
-constexpr uint8_t BACKLIGHT_NIGHT = 60;
+// 夜間時の輝度を80に調整し、明るすぎないようにする
+constexpr uint8_t BACKLIGHT_NIGHT = 80;
 
 constexpr int MEDIAN_BUFFER_SIZE = 10;
 


### PR DESCRIPTION
## 日本語
- NIGHT モードのバックライト輝度を 80 に変更し、明るすぎないよう調整しました
- `.clang-format` と `.clang-tidy` を実行しました（警告多数のため失敗）

## English
- Set `BACKLIGHT_NIGHT` to 80 to avoid excessive brightness at night
- Ran `.clang-format` and attempted `.clang-tidy` (failed due to warnings)


------
https://chatgpt.com/codex/tasks/task_e_68862f3b8cdc8322906e591fbcdbc11a