### PR TITLE
Enable ambient light sensor / 環境光センサー有効化

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -15,7 +15,8 @@ constexpr bool SENSOR_OIL_PRESSURE_PRESENT = true;
 constexpr bool SENSOR_WATER_TEMP_PRESENT = true;
 // 油温センサーを使用するかどうか
 constexpr bool SENSOR_OIL_TEMP_PRESENT = true;
-constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = false;  // ALS を無効化
+// 照度センサーを使用する場合は true
+constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
 
 // ── 電圧降下補正 ──
 // 0.3sq ケーブル往復14mで約0.137Vの降下を想定


### PR DESCRIPTION
## Summary / 概要
- enable the ambient light sensor by setting `SENSOR_AMBIENT_LIGHT_PRESENT` to `true`

## Testing
- `clang-format` executed
- `clang-tidy` attempted (failed: no compilation database)
- `pio test` failed to install espressif32 platform due to blocked network access

------
https://chatgpt.com/codex/tasks/task_e_688666df30008322a7746503d292046b