### PR TITLE
Fix water temp gauge redzone (水温バーの異常表示修正)

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -39,6 +39,12 @@ void drawFillArcMeter(M5Canvas /*unused*/ &canvas, float value, float minValue, 
   const uint16_t INACTIVE_COLOR = 0x18E3;         // メーター全体の背景色
   const uint16_t TEXT_COLOR = COLOR_WHITE;        // テキストの色
 
+  // 温度が199℃以上ならセンサー異常として扱う
+  if (strcmp(unit, "Celsius") == 0 && value >= 199.0f)
+  {
+    value = 0.0f;
+  }
+
   // 値を範囲内に収める
   float clampedValue = value;
   if (clampedValue < minValue)
@@ -187,12 +193,6 @@ void drawFillArcMeter(M5Canvas /*unused*/ &canvas, float value, float minValue, 
     canvas.print(combinedLabel);
   }
 
-
-  if (strcmp(unit, "Celsius") == 0 && value >= 199.0f)
-  {
-    // 199℃以上は異常値として 0 扱い
-    value = 0.0f;
-  }
   // 値を右下に表示
   char valueText[10];
   if (isUseDecimal)


### PR DESCRIPTION
## Summary / 概要
- treat sensor values >=199°C as error before drawing gauge
- remove duplicated error handling for water temperature

## Testing / テスト
- `clang-format -i src/DrawFillArcMeter.h`
- `clang-tidy src/DrawFillArcMeter.h -- -Iinclude` *(failed: 'M5GFX.h' file not found)*
- `pio test` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6886ef1e57608322ba057f6fa3e43d58