### PR TITLE
バックライトの照度フィルタ改善 / Improve ambient light filtering

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -75,8 +75,6 @@ constexpr uint8_t BACKLIGHT_DAY = 255;
 constexpr uint8_t BACKLIGHT_DUSK = 200;
 constexpr uint8_t BACKLIGHT_NIGHT = 60;
 
-constexpr int MEDIAN_BUFFER_SIZE = 10;
-
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;
 

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -6,7 +6,10 @@
 extern BrightnessMode currentBrightnessMode;
 
 // ALS 測定間隔 [ms]
-constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 8000;
+constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 1000;
+
+// ALS フィルタの係数
+constexpr float LUX_FILTER_ALPHA = 0.2f;
 
 void updateBacklightLevel();
 


### PR DESCRIPTION
## 概要 / Summary
- 照度計測結果を指数移動平均で平滑化
- ALS 測定間隔を 1 秒に短縮

## Testing
- `clang-format -i src/modules/backlight.cpp src/modules/backlight.h include/config.h`
- `clang-tidy src/modules/backlight.cpp src/modules/backlight.h include/config.h -- -Iinclude` *(errors shown but command executed)*
- `pio test` *(failed: platform files could not be downloaded)*


------
https://chatgpt.com/codex/tasks/task_e_688765318bc0832296ab0c061a613d1a