### PR TITLE
Add camera-based brightness control / カメラ輝度制御を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 - 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
 - 各種設定は `include/config.h` の定数で変更可能
 - 水温・油温は500ms間隔で取得し、2サンプル平均を1秒ごとに更新
-- 周囲光センサーによる自動調光（デフォルト無効）
+- カメラ画像による自動調光（デフォルト無効）
 - デモモードでセンサー無しでも動作確認可能
 
 ### ハードウェア構成
@@ -135,7 +135,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 - Digital + bar graph temperature display
 - Most settings are in `include/config.h`
 - Water and oil temperatures are sampled every 500 ms and averaged over 2 samples (updated every second)
-- Automatic backlight brightness using the ambient light sensor (disabled by default)
+ - Automatic backlight brightness using the camera image (disabled by default)
 - Demo mode lets you test without sensors connected
 
 ### Hardware Configuration

--- a/include/config.h
+++ b/include/config.h
@@ -15,8 +15,10 @@ constexpr bool SENSOR_OIL_PRESSURE_PRESENT = true;
 constexpr bool SENSOR_WATER_TEMP_PRESENT = true;
 // 油温センサーを使用するかどうか
 constexpr bool SENSOR_OIL_TEMP_PRESENT = true;
+// カメラを使った輝度調整を行う場合は true
+constexpr bool SENSOR_CAMERA_PRESENT = true;
 // 照度センサーを使用する場合は true
-constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
+constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = false;
 
 // ── 電圧降下補正 ──
 // 0.3sq ケーブル往復14mで約0.137Vの降下を想定

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ lib_deps =
   m5stack/M5Unified@^0.1.17
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
+  espressif/esp32-camera@^2.0.0
 lib_ldf_mode = deep
 monitor_speed = 115200
 upload_port = COM11
@@ -34,6 +35,7 @@ lib_deps =
   m5stack/M5Unified@^0.1.17
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
+  espressif/esp32-camera@^2.0.0
 lib_ldf_mode = deep
 monitor_speed = 115200
 test_filter = ci_dummy

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -7,6 +7,8 @@ extern BrightnessMode currentBrightnessMode;
 
 // ALS 測定間隔 [ms]
 constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 8000;
+// カメラ輝度測定間隔 [ms]
+constexpr uint16_t CAMERA_MEASUREMENT_INTERVAL_MS = 8000;
 
 void updateBacklightLevel();
 


### PR DESCRIPTION
## Summary / 概要
- enable automatic brightness using camera frames
- disable ambient light sensor by default
- initialize esp32-camera when configured
- update README for new method
- include esp32-camera library in PlatformIO settings

## Testing / テスト
- `clang-tidy src/main.cpp src/modules/backlight.cpp -p .` *(failed: no compilation database)*
- `platformio test` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68876ae1018883229939c6b25fa4f197