### PR TITLE
Add ALS-based auto brightness control / ALS による自動輝度調整の追加

### DIFF
--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -3,10 +3,13 @@
 
 #include "config.h"
 
-extern BrightnessMode currentBrightnessMode;
-
 // ALS 測定間隔 [ms]
-constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 8000;
+constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 200;
+
+// ── 自動調光アルゴリズム用パラメータ ──
+constexpr float ALS_EWMA_ALPHA = 0.20F;         // EWMA 係数
+constexpr float ALS_HYST_MARGIN_RATIO = 0.10F;  // ヒステリシス閾値比
+constexpr uint8_t BRIGHTNESS_STEP_PERCENT = 5;  // 調光ステップ [%]
 
 void updateBacklightLevel();
 


### PR DESCRIPTION
## Summary / 概要
- implement automatic brightness control using ambient light sensor
- apply screen light compensation, EWMA smoothing and hysteresis
- add parameter constants for the new algorithm
- note about measuring during PWM off-time is kept as a placeholder

## Testing / テスト
- `clang-format -i src/modules/backlight.cpp src/modules/backlight.h src/main.cpp`
- `clang-tidy src/modules/backlight.cpp -- -Isrc -Iinclude` *(fails: 15105 warnings and 1 error)*
- `pio test -e m5stack-cores3-ci` *(failed to install dependencies due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_688795ba584083229bf6622caf82be77