### PR TITLE
Fix ALS delay / ALS積分時間の定数化

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -18,7 +18,8 @@ static auto measureLuxWithoutBacklight() -> uint16_t
 {
   uint8_t prevBrightness = display.getBrightness();
   display.setBrightness(0);
-  delayMicroseconds(500);
+  // センサーの積分時間分待機
+  delay(ALS_INTEGRATION_TIME_MS);
   uint16_t lux = CoreS3.Ltr553.getAlsValue();
   display.setBrightness(prevBrightness);
   return lux;

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -7,6 +7,8 @@ extern BrightnessMode currentBrightnessMode;
 
 // ALS 測定間隔 [ms]
 constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 8000;
+// ALS 積分時間 [ms]
+constexpr uint16_t ALS_INTEGRATION_TIME_MS = 300;
 
 void updateBacklightLevel();
 


### PR DESCRIPTION
## Summary / 概要
- define `ALS_INTEGRATION_TIME_MS` constant
- wait `ALS_INTEGRATION_TIME_MS` after turning off the backlight before measuring lux

## Testing / テスト
- `clang-format` and attempted `clang-tidy`
- `pio test -e m5stack-cores3-ci` *(failed: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68879f8b471c8322a781d83675f10336