### PR TITLE
ALS設定を1倍ゲインと100msに変更 / Set ALS gain to 1x and integration time to 100ms

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,7 @@ void setup()
     ltr553Params.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_100MS;
     CoreS3.Ltr553.begin(&ltr553Params);
     // 通常はスタンバイにしておき、測定時のみアクティブにする
-    CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STANDBY_MODE);
+    CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STAND_BY_MODE);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,7 +79,8 @@ void setup()
     ltr553Params.als_gain = LTR5XX_ALS_GAIN_1X;
     ltr553Params.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_100MS;
     CoreS3.Ltr553.begin(&ltr553Params);
-    CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
+    // 通常はスタンバイにしておき、測定時のみアクティブにする
+    CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STANDBY_MODE);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,8 +75,9 @@ void setup()
   {
     // ALS のゲインと積分時間を設定してから初期化
     Ltr5xx_Init_Basic_Para ltr553Params = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
-    ltr553Params.als_gain = LTR5XX_ALS_GAIN_48X;
-    ltr553Params.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_300MS;
+    // 感度を1倍、積分時間を100msに設定
+    ltr553Params.als_gain = LTR5XX_ALS_GAIN_1X;
+    ltr553Params.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_100MS;
     CoreS3.Ltr553.begin(&ltr553Params);
     CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
   }

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -18,8 +18,11 @@ static auto measureLuxWithoutBacklight() -> uint16_t
 {
   uint8_t prevBrightness = display.getBrightness();
   display.setBrightness(0);
-  delayMicroseconds(500);
+  // ALS を有効化して測定する
+  CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
+  delay(100);  // 積分時間分だけ待機
   uint16_t lux = CoreS3.Ltr553.getAlsValue();
+  CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STANDBY_MODE);
   display.setBrightness(prevBrightness);
   return lux;
 }

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -20,7 +20,6 @@ static auto measureLuxWithoutBacklight() -> uint16_t
   display.setBrightness(0);
   // ALS を有効化して測定する
   CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
-  delay(100);  // 積分時間分だけ待機
   uint16_t lux = CoreS3.Ltr553.getAlsValue();
   CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STAND_BY_MODE);
   display.setBrightness(prevBrightness);

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -22,7 +22,7 @@ static auto measureLuxWithoutBacklight() -> uint16_t
   CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
   delay(100);  // 積分時間分だけ待機
   uint16_t lux = CoreS3.Ltr553.getAlsValue();
-  CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STANDBY_MODE);
+  CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STAND_BY_MODE);
   display.setBrightness(prevBrightness);
   return lux;
 }


### PR DESCRIPTION
## Summary / 概要
- ALSの初期設定を1倍ゲイン・積分時間100msに変更しました
- Applied clang-format and attempted clang-tidy

## Testing / テスト
- `clang-format -i src/main.cpp`
- `clang-tidy src/main.cpp -- -Iinclude` (failed: 'M5CoreS3.h' file not found)
- `pio run -e m5stack-cores3` *(failed: network access to platformio registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6888532c418c8322b088421f0d037c09