### PR TITLE
照度センサー起動時の輝度初期化 / Initialize backlight on startup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@ int fpsFrameCounter = 0;
 int currentFps = 0;
 unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
 unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
+unsigned long initialAlsTime = 0;   // ALS 初期化時刻
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -81,13 +82,20 @@ void setup()
     CoreS3.Ltr553.begin(&ltr553Params);
     // 通常はスタンバイにしておき、測定時のみアクティブにする
     CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_STAND_BY_MODE);
+    initializeBacklight();
+    initialAlsTime = millis();
+  }
+  else
+  {
+    initializeBacklight();
+    initialAlsTime = millis();
   }
 }
 
 // ────────────────────── loop() ──────────────────────
 void loop()
 {
-  static unsigned long lastAlsMeasurementTime = 0;
+  static unsigned long lastAlsMeasurementTime = initialAlsTime;
   unsigned long nowUs = micros();
   // 前のフレームから16.6ms未満なら待機
   if (lastFrameTimeUs != 0 && nowUs - lastFrameTimeUs < FRAME_INTERVAL_US)

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -70,3 +70,31 @@ void updateBacklightLevel()
     display.setBrightness(targetBrightness);
   }
 }
+
+// ────────────────────── 初期輝度設定 ──────────────────────
+void initializeBacklight()
+{
+  if (!SENSOR_AMBIENT_LIGHT_PRESENT)
+  {
+    currentBrightnessMode = BrightnessMode::Day;
+    display.setBrightness(BACKLIGHT_DAY);
+    return;
+  }
+
+  // 初回測定を行い、バッファを同値で埋める
+  uint16_t lux = measureLuxWithoutBacklight();
+  for (int i = 0; i < MEDIAN_BUFFER_SIZE; ++i)
+  {
+    luxSamples[i] = lux;
+  }
+  luxSampleIndex = 0;
+
+  BrightnessMode mode = (lux >= LUX_THRESHOLD_DAY)    ? BrightnessMode::Day
+                        : (lux >= LUX_THRESHOLD_DUSK) ? BrightnessMode::Dusk
+                                                      : BrightnessMode::Night;
+  currentBrightnessMode = mode;
+  uint8_t targetBrightness = (mode == BrightnessMode::Day)    ? BACKLIGHT_DAY
+                             : (mode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
+                                                              : BACKLIGHT_NIGHT;
+  display.setBrightness(targetBrightness);
+}

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -9,5 +9,6 @@ extern BrightnessMode currentBrightnessMode;
 constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 8000;
 
 void updateBacklightLevel();
+void initializeBacklight();
 
 #endif  // BACKLIGHT_H


### PR DESCRIPTION
## 概要 / Summary
- 初回起動時に環境光を測定し、リングバッファを初期化する`initializeBacklight`を追加
- `setup()`で`initializeBacklight()`を呼び出して再起動後も同一環境なら同じ明るさを維持

## テスト / Testing
- `clang-format`と`clang-tidy`を実行
- `platformio`が無いためテストは未実施

------
https://chatgpt.com/codex/tasks/task_e_6889112537448322a5dc42394127cae3