### PR TITLE
fix: 4.9V以上の油圧を0扱い / Treat oil pressure ≥4.9V as zero

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -162,7 +162,7 @@ void updateGauges()
 
   float pressureAvg = calculateAverage(oilPressureSamples);
   pressureAvg = std::min(pressureAvg, MAX_OIL_PRESSURE_DISPLAY);
-  if (pressureAvg >= 11.0F)
+  if (pressureAvg >= 11.0F || oilPressureOverVoltage)
   {
     // ショートエラー時は 0 として扱い、最大値もリセット
     pressureAvg = 0.0F;

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -11,6 +11,7 @@ extern Adafruit_ADS1015 adsConverter;
 extern float oilPressureSamples[PRESSURE_SAMPLE_SIZE];
 extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
+extern bool oilPressureOverVoltage;
 
 void acquireSensorData();
 

--- a/test/test_sensor_conversion.cpp
+++ b/test/test_sensor_conversion.cpp
@@ -21,6 +21,10 @@ void test_convert_voltage_to_oil_pressure()
   result = convertVoltageToOilPressure(0.25f);
   // 0.5V 未満は0として扱う
   TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, result);
+
+  result = convertVoltageToOilPressure(4.9f);
+  // 4.9V 以上はショートエラーとして0扱い
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, result);
 }
 
 // 温度変換のテスト


### PR DESCRIPTION
## 概要 / Summary
- 油圧センサーで4.9V以上を検出した場合、ショートエラーとして0を返すよう変更しました。
- これに伴いフラグを追加し、ゲージ表示でも0として扱うようにしました。
- 変換関数のテストを更新し、4.9V入力時に0となることを確認します。

## テスト / Testing
- `clang-format` と `clang-tidy` を実行
- `platformio test` を試みましたが、依存パッケージ取得がブロックされたため実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_688a0e105fc88322bbdd96b4dd094ce8