### PR TITLE
デバッグ時に照度を出力 / Print lux in debug mode

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -55,6 +55,12 @@ void updateBacklightLevel()
 
   uint16_t medianLux = calculateMedian(luxSamples);
 
+  // デバッグモードでは照度を出力
+  if (DEBUG_MODE_ENABLED)
+  {
+    Serial.printf("[ALS] lux:%u, median:%u\n", measuredLux, medianLux);
+  }
+
   BrightnessMode newMode = (medianLux >= LUX_THRESHOLD_DAY)    ? BrightnessMode::Day
                            : (medianLux >= LUX_THRESHOLD_DUSK) ? BrightnessMode::Dusk
                                                                : BrightnessMode::Night;


### PR DESCRIPTION
## 日本語
デバッグモード有効時、バックライト更新処理で計測した照度をシリアル出力するようにしました。

## English
When DEBUG_MODE_ENABLED is true, the measured ambient light value is printed to serial in `updateBacklightLevel`.

------
https://chatgpt.com/codex/tasks/task_e_688a278e63b08322975f18aa0ae825cf