### PR TITLE
fix/backlight_spike_handling

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -11,6 +11,10 @@ BrightnessMode currentBrightnessMode = BrightnessMode::Day;
 // ALS サンプルバッファ
 uint16_t luxSamples[MEDIAN_BUFFER_SIZE] = {};
 int luxSampleIndex = 0;  // 次に書き込むインデックス
+// 直近の有効な照度値
+static uint16_t lastValidLux = 0;
+// 異常とみなす照度変化の閾値
+constexpr uint16_t LUX_JUMP_THRESHOLD = 1000;
 
 // ────────────────────── 輝度測定 ──────────────────────
 // バックライトを消して輝度を測定
@@ -50,6 +54,15 @@ void updateBacklightLevel()
   }
 
   uint16_t measuredLux = measureLuxWithoutBacklight();
+
+  // 急激な変化は異常値として無視する
+  if (lastValidLux != 0 && std::abs(static_cast<int>(measuredLux) - static_cast<int>(lastValidLux)) > LUX_JUMP_THRESHOLD)
+  {
+    // サンプルバッファを更新せずリターン
+    return;
+  }
+
+  lastValidLux = measuredLux;
 
   // サンプルをリングバッファへ格納
   luxSamples[luxSampleIndex] = measuredLux;


### PR DESCRIPTION
## Summary / 概要
- Ignore sudden lux spikes when updating backlight brightness
- 照度が急激に変化した場合は更新を無視する処理を追加

## Testing / テスト
- `clang-format` と `clang-tidy` を実行
- `platformio test` (依存取得の段階で失敗)


------
https://chatgpt.com/codex/tasks/task_e_688a5fe35e7083228c683cf2e5ebf292