### PR TITLE
fix: update M5Unified library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ platform = espressif32
 board = m5stack-cores3
 framework = arduino
 lib_deps =
-  m5stack/M5Unified@^0.1.17
+  m5stack/M5Unified@^0.2.7
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep
@@ -31,7 +31,7 @@ platform = espressif32
 board = m5stack-cores3
 framework = arduino
 lib_deps =
-  m5stack/M5Unified@^0.1.17
+  m5stack/M5Unified@^0.2.7
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -57,8 +57,8 @@ void updateBacklightLevel()
   {
     currentBrightnessMode = newMode;
     int targetBrightness = (newMode == BrightnessMode::Day)    ? BACKLIGHT_DAY
-                               : (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
-                                                                   : BACKLIGHT_NIGHT;
+                           : (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
+                                                               : BACKLIGHT_NIGHT;
     display.setBrightness(targetBrightness);
   }
 }


### PR DESCRIPTION
## Summary / 概要
- update M5Unified to 0.2.7 to avoid deprecation warnings
- format backlight.cpp

## Testing / テスト
- `clang-format -i src/main.cpp src/modules/display.cpp src/modules/fps_display.cpp src/modules/backlight.cpp src/modules/sensor.cpp include/config.h src/modules/sensor.h src/modules/backlight.h src/modules/fps_display.h src/modules/display.h src/DrawFillArcMeter.h test/test_sensor_conversion.cpp test/ci_dummy/test_dummy.cpp`
- `clang-tidy src/main.cpp -- -std=c++17` *(fails: 'M5CoreS3.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b474c6b70832294e4bf38a07049ee