### PR TITLE
Fix ALS sample buffer handling / 照度サンプルバッファの扱い修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ void setup()
     ltr553Params.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_100MS;
     CoreS3.Ltr553.begin(&ltr553Params);
     CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
+    // 初回起動時に照度を取得して輝度を決定
+    updateBacklightLevel();
   }
 }
 

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -36,7 +36,6 @@ void updateBacklightLevel()
   }
 
   int currentLux = CoreS3.Ltr553.getAlsValue();
-
   // サンプルをリングバッファへ格納
   luxSamples[luxSampleIndex] = currentLux;
   luxSampleIndex = (luxSampleIndex + 1) % MEDIAN_BUFFER_SIZE;
@@ -57,8 +56,8 @@ void updateBacklightLevel()
   {
     currentBrightnessMode = newMode;
     int targetBrightness = (newMode == BrightnessMode::Day)    ? BACKLIGHT_DAY
-                               : (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
-                                                                   : BACKLIGHT_NIGHT;
+                           : (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
+                                                               : BACKLIGHT_NIGHT;
     display.setBrightness(targetBrightness);
   }
 }


### PR DESCRIPTION
## Summary
- remove first-time sample filling
- keep brightness initialization on startup
- keep periodic updates

## 概要
- 初回サンプルをバッファ全体に埋め込む処理を削除
- 起動時に照度取得して輝度設定する処理を維持
- ループでの定期更新処理を維持

## Testing
- `clang-format -i src/main.cpp src/modules/backlight.cpp src/modules/backlight.h`
- `clang-tidy src/main.cpp -- -std=c++17` *(fails: 'M5CoreS3.h' file not found)*
- `clang-tidy src/modules/backlight.cpp -- -std=c++17` *(fails: 'config.h' file not found)*
- `clang-tidy src/modules/backlight.h -- -std=c++17` *(fails: invalid argument '-std=c++17' not allowed with 'C')*
- `pip install platformio`
- `pio test` *(fails: HTTPClientError due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_688af26a07f08322a10d17c878757984