### PR TITLE
Touch menu display / タッチメニュー表示

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,8 @@ int fpsFrameCounter = 0;
 int currentFps = 0;
 unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
 unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
+bool isMenuVisible = false;         // メニュー表示中かどうか
+static bool wasTouched = false;     // 前回タッチされていたか
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -99,14 +101,34 @@ void loop()
   lastFrameTimeUs = nowUs;
   unsigned long now = millis();
 
+  M5.update();
+
   if (now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
   {
     updateBacklightLevel();
     lastAlsMeasurementTime = now;
   }
 
+  bool touched = M5.Touch.getCount() > 0;
+  if (touched && !wasTouched)
+  {
+    isMenuVisible = !isMenuVisible;
+    if (isMenuVisible)
+    {
+      drawMenuScreen();
+    }
+    else
+    {
+      resetGaugeState();
+    }
+  }
+  wasTouched = touched;
+
   acquireSensorData();
-  updateGauges();
+  if (!isMenuVisible)
+  {
+    updateGauges();
+  }
 
   fpsFrameCounter++;
   if (now - lastFpsSecond >= FPS_INTERVAL_MS)

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+// 【 メニュー画面画画 】
 #include <limits>
 
 #include "DrawFillArcMeter.h"
@@ -205,6 +206,39 @@ void updateGauges()
   recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
   recordedMaxWaterTemp = std::max(recordedMaxWaterTemp, smoothWaterTemp);
   recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
-
   renderDisplayAndLog(pressureValue, smoothWaterTemp, oilTempValue, recordedMaxOilTempTop);
-}
+
+  // ────────────────────── メニュー画面描画 ──────────────────────
+  void drawMenuScreen()
+  {
+    mainCanvas.fillScreen(COLOR_BLACK);
+    mainCanvas.setFont(&fonts::Font0);
+    mainCanvas.setTextSize(1);
+    mainCanvas.setTextColor(COLOR_WHITE);
+
+    mainCanvas.setCursor(10, 30);
+    mainCanvas.printf("OIL.P MAX: %.1f bar", recordedMaxOilPressure);
+
+    mainCanvas.setCursor(10, 60);
+    mainCanvas.printf("WATER.T MAX: %.1f C", recordedMaxWaterTemp);
+
+    mainCanvas.setCursor(10, 90);
+    mainCanvas.printf("OIL.T MAX: %d C", recordedMaxOilTempTop);
+
+    int lux = SENSOR_AMBIENT_LIGHT_PRESENT ? CoreS3.Ltr553.getAlsValue() : 0;
+    mainCanvas.setCursor(10, 120);
+    mainCanvas.printf("LUX: %d", lux);
+
+    mainCanvas.pushSprite(0, 0);
+  }
+
+  // ────────────────────── ゲージ状態リセット ──────────────────────
+  void resetGaugeState()
+  {
+    pressureGaugeInitialized = false;
+    waterGaugeInitialized = false;
+    prevPressureValue = std::numeric_limits<float>::quiet_NaN();
+    prevWaterTempValue = std::numeric_limits<float>::quiet_NaN();
+    displayCache = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
+                    std::numeric_limits<float>::quiet_NaN(), INT16_MIN};
+  }

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -13,5 +13,7 @@ extern int currentFps;
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp);
 void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp);
 void updateGauges();
+void drawMenuScreen();
+void resetGaugeState();
 
 #endif  // DISPLAY_H


### PR DESCRIPTION
## English
Implemented a touch-controlled menu. Tapping the screen toggles a menu that shows maximum oil temperature, maximum water temperature, maximum oil pressure and ambient light level. Tapping again returns to the gauge screen.

## 日本語
タッチ操作でメニュー画面を開閉できるようにしました。メニューでは油温MAX・水温MAX・油圧MAXと照度を表示します。再度タッチすると元のメーター画面へ戻ります。

------
https://chatgpt.com/codex/tasks/task_e_688b4dfded288322834345f9438ba273