### PR TITLE
CI手順にGitHub Actions待機を追加 / Wait for GitHub Actions in CI instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,4 @@
 - コード中のコメントは日本語で記述してください。/ Write code comments in Japanese.
 - コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
 - 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.
-- コードを変更したら `act -j build` でCIを実行し、失敗した場合は修正して再度実行してください。プッシュした後は GitHub Actions が完了するまで待ち、失敗したら修正して再度プッシュしてください。/ After modifying code, run `act -j build` to execute CI locally. If it fails, fix the issues and rerun. After pushing, wait for the GitHub Actions run to finish. If it fails, fix the issues and push again.
+- コードを変更したら `act -j build` を実行してCIを確認し、プッシュ後は GitHub Actions の終了を待ち、エラーがあれば修正して再度プッシュしてください。/ After modifying code, run `act -j build` to check CI locally. After pushing, wait for GitHub Actions to finish and push again if errors occur.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 - コード中のコメントは日本語で記述してください。/ Write code comments in Japanese.
 - コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
 - 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.
+- コードを変更したら `act -j build` でCIを実行し、失敗した場合は修正して再度実行してください。プッシュした後は GitHub Actions が完了するまで待ち、失敗したら修正して再度プッシュしてください。/ After modifying code, run `act -j build` to execute CI locally. If it fails, fix the issues and rerun. After pushing, wait for the GitHub Actions run to finish. If it fails, fix the issues and push again.


### PR DESCRIPTION
## Summary / 概要
- `AGENTS.md` のCI手順を更新し、ローカルで `act -j build` 実行後にGitHub Actionsが完了するまで待つよう追記しました

## Testing / テスト結果
- `clang-format` を実行
- `clang-tidy` を実行（多数の警告とエラーが発生）
- `act -j build` を試行するも `act` コマンドが存在せず失敗


------
https://chatgpt.com/codex/tasks/task_e_688b737c898883229212807af305d0b9