### PR TITLE
Add menu info: lux and oil temp duration / メニュー情報追加

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@ unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
 unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
 bool isMenuVisible = false;         // メニュー表示中かどうか
 static bool wasTouched = false;     // 前回タッチされていたか
+// 油温が120度を超えていた累積時間 [ms]
+unsigned long oilTempOver120TimeMs = 0;
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -91,6 +93,7 @@ void setup()
 void loop()
 {
   static unsigned long lastAlsMeasurementTime = 0;
+  static unsigned long lastOilTempCheck = 0;
   unsigned long nowUs = micros();
   // 前のフレームから16.6ms未満なら待機
   if (lastFrameTimeUs != 0 && nowUs - lastFrameTimeUs < FRAME_INTERVAL_US)
@@ -100,6 +103,16 @@ void loop()
   }
   lastFrameTimeUs = nowUs;
   unsigned long now = millis();
+  if (lastOilTempCheck == 0)
+  {
+    lastOilTempCheck = now;
+  }
+  float currentOilTemp = calculateAverage(oilTemperatureSamples);
+  if (currentOilTemp >= 120.0F)
+  {
+    oilTempOver120TimeMs += now - lastOilTempCheck;
+  }
+  lastOilTempCheck = now;
 
   M5.update();
 

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -8,6 +8,10 @@
 // ────────────────────── グローバル変数 ──────────────────────
 // 現在の輝度モード
 BrightnessMode currentBrightnessMode = BrightnessMode::Day;
+// 最新の照度値
+int currentLuxValue = 0;
+// サンプルから計算した中央値
+int medianLuxValue = 0;
 // ALS サンプルバッファ
 int luxSamples[MEDIAN_BUFFER_SIZE] = {};
 int luxSampleIndex = 0;  // 次に書き込むインデックス
@@ -36,11 +40,13 @@ void updateBacklightLevel()
   }
 
   int currentLux = CoreS3.Ltr553.getAlsValue();
+  currentLuxValue = currentLux;
   // サンプルをリングバッファへ格納
   luxSamples[luxSampleIndex] = currentLux;
   luxSampleIndex = (luxSampleIndex + 1) % MEDIAN_BUFFER_SIZE;
 
   int medianLux = calculateMedian(luxSamples);
+  medianLuxValue = medianLux;
 
   // デバッグモードでは照度を出力
   if (DEBUG_MODE_ENABLED)

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -4,6 +4,10 @@
 #include "config.h"
 
 extern BrightnessMode currentBrightnessMode;
+// 現在の照度値
+extern int currentLuxValue;
+// 照度の中央値
+extern int medianLuxValue;
 
 // ALS 測定間隔 [ms]
 constexpr int ALS_MEASUREMENT_INTERVAL_MS = 8000;

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 
 #include "DrawFillArcMeter.h"
+#include "backlight.h"
 #include "fps_display.h"
 
 // ────────────────────── グローバル変数 ──────────────────────
@@ -212,22 +213,32 @@ void updateGauges()
 void drawMenuScreen()
 {
   mainCanvas.fillScreen(COLOR_BLACK);
-  mainCanvas.setFont(&fonts::Font0);
-  mainCanvas.setTextSize(1);
+  mainCanvas.setFont(&fonts::FreeMonoOblique18pt7b);
+  mainCanvas.setTextSize(0);
   mainCanvas.setTextColor(COLOR_WHITE);
 
-  mainCanvas.setCursor(10, 30);
+  int y = 30;
+  mainCanvas.setCursor(10, y);
   mainCanvas.printf("OIL.P MAX: %.1f bar", recordedMaxOilPressure);
+  y += mainCanvas.fontHeight() + 4;
 
-  mainCanvas.setCursor(10, 60);
+  mainCanvas.setCursor(10, y);
   mainCanvas.printf("WATER.T MAX: %.1f C", recordedMaxWaterTemp);
+  y += mainCanvas.fontHeight() + 4;
 
-  mainCanvas.setCursor(10, 90);
+  mainCanvas.setCursor(10, y);
   mainCanvas.printf("OIL.T MAX: %d C", recordedMaxOilTempTop);
+  y += mainCanvas.fontHeight() + 4;
 
-  int lux = SENSOR_AMBIENT_LIGHT_PRESENT ? CoreS3.Ltr553.getAlsValue() : 0;
-  mainCanvas.setCursor(10, 120);
-  mainCanvas.printf("LUX: %d", lux);
+  int luxCurrent = SENSOR_AMBIENT_LIGHT_PRESENT ? currentLuxValue : 0;
+  int luxMedian = SENSOR_AMBIENT_LIGHT_PRESENT ? medianLuxValue : 0;
+  mainCanvas.setCursor(10, y);
+  mainCanvas.printf("LUX:%d MED:%d", luxCurrent, luxMedian);
+  y += mainCanvas.fontHeight() + 4;
+
+  unsigned long overMinutes = oilTempOver120TimeMs / 60000UL;
+  mainCanvas.setCursor(10, y);
+  mainCanvas.printf("OIL.T>120:%lu min", overMinutes);
 
   mainCanvas.pushSprite(0, 0);
 }

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -9,6 +9,7 @@
 extern M5GFX display;
 extern M5Canvas mainCanvas;
 extern int currentFps;
+extern unsigned long oilTempOver120TimeMs;
 
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp);
 void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp);


### PR DESCRIPTION
## Summary
- show current and median lux
- track oil temp over 120°C time and display minutes
- use FreeMonoOblique18pt7b font in menu

## テスト
- `clang-format` を実行
- `clang-tidy` はビルド設定不足でエラー
- `platformio test` は依存取得に失敗

------
https://chatgpt.com/codex/tasks/task_e_688b7fb379248322862b72e2315ec3e2