### PR TITLE
メニュー画面処理の分離 / Separate menu screen module

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "config.h"
 #include "modules/backlight.h"
 #include "modules/display.h"
+#include "modules/menu.h"
 #include "modules/sensor.h"
 
 // ── FPS 計測用 ──

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -208,30 +208,6 @@ void updateGauges()
   renderDisplayAndLog(pressureValue, smoothWaterTemp, oilTempValue, recordedMaxOilTempTop);
 }
 
-// ────────────────────── メニュー画面描画 ──────────────────────
-void drawMenuScreen()
-{
-  mainCanvas.fillScreen(COLOR_BLACK);
-  mainCanvas.setFont(&fonts::Font0);
-  mainCanvas.setTextSize(1);
-  mainCanvas.setTextColor(COLOR_WHITE);
-
-  mainCanvas.setCursor(10, 30);
-  mainCanvas.printf("OIL.P MAX: %.1f bar", recordedMaxOilPressure);
-
-  mainCanvas.setCursor(10, 60);
-  mainCanvas.printf("WATER.T MAX: %.1f C", recordedMaxWaterTemp);
-
-  mainCanvas.setCursor(10, 90);
-  mainCanvas.printf("OIL.T MAX: %d C", recordedMaxOilTempTop);
-
-  int lux = SENSOR_AMBIENT_LIGHT_PRESENT ? CoreS3.Ltr553.getAlsValue() : 0;
-  mainCanvas.setCursor(10, 120);
-  mainCanvas.printf("LUX: %d", lux);
-
-  mainCanvas.pushSprite(0, 0);
-}
-
 // ────────────────────── ゲージ状態リセット ──────────────────────
 void resetGaugeState()
 {

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -13,7 +13,6 @@ extern int currentFps;
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp);
 void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp);
 void updateGauges();
-void drawMenuScreen();
 void resetGaugeState();
 
 #endif  // DISPLAY_H

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -1,0 +1,30 @@
+#include "menu.h"
+
+// display.cpp 側で定義している最大値を使用する
+extern float recordedMaxOilPressure;
+extern float recordedMaxWaterTemp;
+extern int recordedMaxOilTempTop;
+
+// メニュー画面を描画する処理
+void drawMenuScreen()
+{
+  mainCanvas.fillScreen(COLOR_BLACK);
+  mainCanvas.setFont(&fonts::Font0);
+  mainCanvas.setTextSize(1);
+  mainCanvas.setTextColor(COLOR_WHITE);
+
+  mainCanvas.setCursor(10, 30);
+  mainCanvas.printf("OIL.P MAX: %.1f bar", recordedMaxOilPressure);
+
+  mainCanvas.setCursor(10, 60);
+  mainCanvas.printf("WATER.T MAX: %.1f C", recordedMaxWaterTemp);
+
+  mainCanvas.setCursor(10, 90);
+  mainCanvas.printf("OIL.T MAX: %d C", recordedMaxOilTempTop);
+
+  int lux = SENSOR_AMBIENT_LIGHT_PRESENT ? CoreS3.Ltr553.getAlsValue() : 0;
+  mainCanvas.setCursor(10, 120);
+  mainCanvas.printf("LUX: %d", lux);
+
+  mainCanvas.pushSprite(0, 0);
+}

--- a/src/modules/menu.h
+++ b/src/modules/menu.h
@@ -1,0 +1,11 @@
+#ifndef MENU_H
+#define MENU_H
+
+#include <M5GFX.h>
+
+#include "display.h"  // mainCanvas を使用するため
+
+// メニュー画面を描画する関数
+void drawMenuScreen();
+
+#endif  // MENU_H


### PR DESCRIPTION
## 概要 / Summary
- メニュー表示用の `drawMenuScreen` 関数を新しい `menu.cpp` と `menu.h` に移動しました
- `display.cpp` から該当コードを削除し、`main.cpp` では新しいヘッダーを参照します

## テスト / Testing
- `clang-format` と `clang-tidy` を実行
- `act -j build` は Docker 未設定のため実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_688b91f9ef988322bc20d6079e50db55