### PR TITLE
タッチメニュー値の整列 / Align touch menu values

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -222,7 +222,7 @@ void drawMenuScreen()
 
   mainCanvas.setCursor(10, 60);
   // こちらも同様に右寄せ表示
-  mainCanvas.printf("WATER.T MAX: %6d", recordedMaxWaterTemp);
+  mainCanvas.printf("WATER.T MAX: %6.1f", recordedMaxWaterTemp);
 
   mainCanvas.setCursor(10, 90);
   // 最大油温値を右寄せで表示


### PR DESCRIPTION
## 概要 / Summary
- メニュー画面の数値表示を右寄せに変更し、インデントを統一しました
- `clang-format` を実行済み、`clang-tidy` はコンパイルデータ不足で警告が出ました
- `act -j build` は Docker が無いため実行できませんでした

## English Summary
- Align numbers in the menu by padding with spaces
- Ran `clang-format`; `clang-tidy` failed due to missing compilation database
- Could not run `act -j build` because Docker is unavailable

------
https://chatgpt.com/codex/tasks/task_e_688c7181fd708322a7e2fc59c011bdb6