### PR TITLE
メニュー画面の窪み風デザインを追加 / Add recessed menu style

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -240,6 +240,7 @@ void drawMenuScreen()
 
   // 戻る案内を左下へ配置
   mainCanvas.setCursor(10, LCD_HEIGHT - 20);
+  mainCanvas.setFont(&fonts::Font0);
   mainCanvas.printf("Tap screen to return");
 
   mainCanvas.pushSprite(0, 0);

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -216,6 +216,15 @@ void drawMenuScreen()
   mainCanvas.setTextSize(1);
   mainCanvas.setTextColor(COLOR_WHITE);
 
+  // 3D風の突き立てているような枠を描く
+  constexpr uint16_t BORDER_LIGHT = rgb565(80, 80, 80);
+  constexpr uint16_t BORDER_DARK = rgb565(20, 20, 20);
+  mainCanvas.drawRect(0, 0, LCD_WIDTH, LCD_HEIGHT, BORDER_DARK);
+  mainCanvas.drawLine(1, 1, LCD_WIDTH - 2, 1, BORDER_LIGHT);
+  mainCanvas.drawLine(1, 1, 1, LCD_HEIGHT - 2, BORDER_LIGHT);
+  mainCanvas.drawLine(1, LCD_HEIGHT - 2, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
+  mainCanvas.drawLine(LCD_WIDTH - 2, 1, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
+
   mainCanvas.setCursor(10, 30);
   mainCanvas.printf("OIL.P MAX: %.1f", recordedMaxOilPressure);
 
@@ -228,6 +237,10 @@ void drawMenuScreen()
   int lux = SENSOR_AMBIENT_LIGHT_PRESENT ? CoreS3.Ltr553.getAlsValue() : 0;
   mainCanvas.setCursor(10, 120);
   mainCanvas.printf("LUX: %d", lux);
+
+  // 戻る案内を左下へ配置
+  mainCanvas.setCursor(10, LCD_HEIGHT - 20);
+  mainCanvas.printf("Tap screen to return");
 
   mainCanvas.pushSprite(0, 0);
 }


### PR DESCRIPTION
## Summary
- メニュー画面を3D風の枠付きに変更
- 左下に「Tap screen to return」を表示

## Testing
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -- -Iinclude` *(警告多数)*
- `act -j build` *(Docker が無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_688c71bf43ec8322b8ac37d53fdf83ed