### PR TITLE
Add median lux display in touch menu / タッチメニューに中央値照度を追加

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -12,6 +12,11 @@ BrightnessMode currentBrightnessMode = BrightnessMode::Day;
 int luxSamples[MEDIAN_BUFFER_SIZE] = {};
 int luxSampleIndex = 0;  // 次に書き込むインデックス
 
+// 直近取得した照度値
+int latestLux = 0;
+// 中央値フィルタ適用後の照度値
+int medianLuxValue = 0;
+
 // ────────────────────── 中央値計算 ──────────────────────
 // サンプル配列から中央値を計算する
 static auto calculateMedian(const int *samples) -> int
@@ -36,11 +41,13 @@ void updateBacklightLevel()
   }
 
   int currentLux = CoreS3.Ltr553.getAlsValue();
+  latestLux = currentLux;
   // サンプルをリングバッファへ格納
   luxSamples[luxSampleIndex] = currentLux;
   luxSampleIndex = (luxSampleIndex + 1) % MEDIAN_BUFFER_SIZE;
 
   int medianLux = calculateMedian(luxSamples);
+  medianLuxValue = medianLux;
 
   // デバッグモードでは照度を出力
   if (DEBUG_MODE_ENABLED)

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -5,6 +5,11 @@
 
 extern BrightnessMode currentBrightnessMode;
 
+// 直近取得した照度値
+extern int latestLux;
+// 中央値フィルタを適用した照度値
+extern int medianLuxValue;
+
 // ALS 測定間隔 [ms]
 constexpr int ALS_MEASUREMENT_INTERVAL_MS = 8000;
 

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 
 #include "DrawFillArcMeter.h"
+#include "backlight.h"
 #include "fps_display.h"
 
 // ────────────────────── グローバル変数 ──────────────────────
@@ -225,9 +226,16 @@ void drawMenuScreen()
   mainCanvas.setCursor(10, 90);
   mainCanvas.printf("OIL.T MAX: %d", recordedMaxOilTempTop);
 
-  int lux = SENSOR_AMBIENT_LIGHT_PRESENT ? CoreS3.Ltr553.getAlsValue() : 0;
   mainCanvas.setCursor(10, 120);
-  mainCanvas.printf("LUX: %d", lux);
+  if (SENSOR_AMBIENT_LIGHT_PRESENT)
+  {
+    // 直近の照度と中央値を表示
+    mainCanvas.printf("LUX:%d MED:%d", latestLux, medianLuxValue);
+  }
+  else
+  {
+    mainCanvas.printf("LUX: N/A");
+  }
 
   mainCanvas.pushSprite(0, 0);
 }


### PR DESCRIPTION
## Summary
- store latest and median lux values
- display both in touch menu

## 概要
- 最新の照度値と中央値照度を保持
- タッチメニューで両方表示するよう修正



------
https://chatgpt.com/codex/tasks/task_e_688c71d97cb883228a89010cea22cd50