### PR TITLE
Update water temp gauge range / 水温メータ範囲を更新

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -52,8 +52,8 @@ constexpr float OIL_PRESSURE_SMOOTHING_ALPHA = 0.3f;
 
 // ── 水温メーター設定 ──
 // 水温メーター下限と上限を80℃〜120℃に設定
-constexpr float WATER_TEMP_METER_MIN = 80.0f;
-constexpr float WATER_TEMP_METER_MAX = 120.0f;
+constexpr float WATER_TEMP_METER_MIN = 85.0f;
+constexpr float WATER_TEMP_METER_MAX = 115.0f;
 
 // ── 画面サイズ ──
 constexpr int LCD_WIDTH = 320;

--- a/include/config.h
+++ b/include/config.h
@@ -51,9 +51,9 @@ constexpr float OIL_PRESSURE_DISCONNECT_THRESHOLD = 0.25f;
 constexpr float OIL_PRESSURE_SMOOTHING_ALPHA = 0.3f;
 
 // ── 水温メーター設定 ──
-// 水温メーター下限と上限を80℃〜105℃に設定
+// 水温メーター下限と上限を80℃〜120℃に設定
 constexpr float WATER_TEMP_METER_MIN = 80.0f;
-constexpr float WATER_TEMP_METER_MAX = 105.0f;
+constexpr float WATER_TEMP_METER_MAX = 120.0f;
 
 // ── 画面サイズ ──
 constexpr int LCD_WIDTH = 320;

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -137,7 +137,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
     {
       mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
     }
-    drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f, COLOR_RED, "Celsius",
+    drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 110.0f, COLOR_RED, "Celsius",
                      "WATER.T", recordedMaxWaterTemp, prevWaterTempValue, 1.0f, false, 160, 60, !waterGaugeInitialized,
                      5.0f, WATER_TEMP_METER_MIN);
     waterGaugeInitialized = true;


### PR DESCRIPTION
## Summary / 概要
- extend water temperature meter up to 120°C
- set red zone at 110°C

## Testing / テスト
- `clang-format` and `clang-tidy` executed *(clang-tidy failed: missing headers)*
- `act -j build` failed due to missing Docker
- `pio run -e m5stack-cores3` failed due to blocked network access

------
https://chatgpt.com/codex/tasks/task_e_688c84bd87d48322a3194e4511a25457