### PR TITLE
メニュー表示の左右配置調整 / Align menu label and value

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -226,34 +226,63 @@ void drawMenuScreen()
   mainCanvas.drawLine(1, LCD_HEIGHT - 2, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
   mainCanvas.drawLine(LCD_WIDTH - 2, 1, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
 
-  mainCanvas.setCursor(10, 30);
+  int y = 30;
+  mainCanvas.setCursor(10, y);
   // ラベルは左寄せ、値は右寄せで表示
   mainCanvas.print("OIL.P MAX:");
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxOilPressure);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 30);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
-  mainCanvas.setCursor(10, 60);
-  // こちらも同様に右寄せ表示
+  y += 30;
+  mainCanvas.setCursor(10, y);
+  mainCanvas.print("OIL.P CURR:");
+  {
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6.1f", displayCache.pressureAvg);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+  }
+
+  y += 30;
+  mainCanvas.setCursor(10, y);
   mainCanvas.print("WATER.T MAX:");
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxWaterTemp);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 60);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
-  mainCanvas.setCursor(10, 90);
-  // 最大油温値を右寄せで表示
+  y += 30;
+  mainCanvas.setCursor(10, y);
+  mainCanvas.print("WATER.T CURR:");
+  {
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6.1f", displayCache.waterTempAvg);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+  }
+
+  y += 30;
+  mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T MAX:");
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6d", recordedMaxOilTempTop);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 90);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
-  mainCanvas.setCursor(10, 120);
+  y += 30;
+  mainCanvas.setCursor(10, y);
+  mainCanvas.print("OIL.T CURR:");
+  {
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6d", static_cast<int>(displayCache.oilTemp));
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+  }
+
+  y += 30;
+  mainCanvas.setCursor(10, y);
 
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {
@@ -261,12 +290,12 @@ void drawMenuScreen()
     mainCanvas.print("LUX:");
     char valStr[16];
     snprintf(valStr, sizeof(valStr), "%6d [ Median: %d ]", latestLux, medianLuxValue);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 120);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
   else
   {
     mainCanvas.print("LUX:");
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, 120);
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
   }
 
   // 戻る案内を左下へ配置

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -286,11 +286,18 @@ void drawMenuScreen()
 
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {
-    // 直近の照度と中央値を表示
-    mainCanvas.print("LUX:");
-    char valStr[16];
-    snprintf(valStr, sizeof(valStr), "%6d [ Median: %d ]", latestLux, medianLuxValue);
+    // 現在値を表示
+    mainCanvas.print("LUX CURR:");
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6d", latestLux);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+
+    y += 30;
+    mainCanvas.setCursor(10, y);
+    mainCanvas.print("LUX MEDIAN:");
+    char medStr[8];
+    snprintf(medStr, sizeof(medStr), "%6d", medianLuxValue);
+    mainCanvas.drawRightString(medStr, LCD_WIDTH - 10, y);
   }
   else
   {

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -227,27 +227,46 @@ void drawMenuScreen()
   mainCanvas.drawLine(LCD_WIDTH - 2, 1, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
 
   mainCanvas.setCursor(10, 30);
-  // 数値部分を右寄せにし、インデントを揃える
-  mainCanvas.printf("OIL.P MAX: %6.1f", recordedMaxOilPressure);
+  // ラベルは左寄せ、値は右寄せで表示
+  mainCanvas.print("OIL.P MAX:");
+  {
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxOilPressure);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 30);
+  }
 
   mainCanvas.setCursor(10, 60);
   // こちらも同様に右寄せ表示
-  mainCanvas.printf("WATER.T MAX: %6.1f", recordedMaxWaterTemp);
+  mainCanvas.print("WATER.T MAX:");
+  {
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxWaterTemp);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 60);
+  }
 
   mainCanvas.setCursor(10, 90);
   // 最大油温値を右寄せで表示
-  mainCanvas.printf("OIL.T MAX: %6d", recordedMaxOilTempTop);
+  mainCanvas.print("OIL.T MAX:");
+  {
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6d", recordedMaxOilTempTop);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 90);
+  }
 
   mainCanvas.setCursor(10, 120);
 
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {
     // 直近の照度と中央値を表示
-    mainCanvas.printf("LUX:%6d [ Median: %d ]", latestLux, medianLuxValue);
+    mainCanvas.print("LUX:");
+    char valStr[16];
+    snprintf(valStr, sizeof(valStr), "%6d [ Median: %d ]", latestLux, medianLuxValue);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, 120);
   }
   else
   {
-    mainCanvas.printf("LUX: Disabled");
+    mainCanvas.print("LUX:");
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, 120);
   }
 
   // 戻る案内を左下へ配置


### PR DESCRIPTION
## Summary / 概要
- メニュー内のラベルを左寄せ、値を右寄せに変更しました
- LUX 表示も同様に調整しました

## Testing / テスト
- `clang-format` を実行
- `clang-tidy` は多数の警告とヘッダ欠如により失敗しました
- `act -j build` は `act` コマンドが存在せず実行できませんでした


------
https://chatgpt.com/codex/tasks/task_e_688cae76dec08322ba2b8139dd57ac6a