### PR TITLE
Fix menu line spacing / メニュー行間調整

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -226,19 +226,20 @@ void drawMenuScreen()
   mainCanvas.drawLine(1, LCD_HEIGHT - 2, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
   mainCanvas.drawLine(LCD_WIDTH - 2, 1, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
 
+  // 行間を広げるために表示位置を調整
   mainCanvas.setCursor(10, 30);
   // 数値部分を右寄せにし、インデントを揃える
   mainCanvas.printf("OIL.P MAX: %6.1f", recordedMaxOilPressure);
 
-  mainCanvas.setCursor(10, 60);
+  mainCanvas.setCursor(10, 70);
   // こちらも同様に右寄せ表示
   mainCanvas.printf("WATER.T MAX: %6.1f", recordedMaxWaterTemp);
 
-  mainCanvas.setCursor(10, 90);
+  mainCanvas.setCursor(10, 110);
   // 最大油温値を右寄せで表示
   mainCanvas.printf("OIL.T MAX: %6d", recordedMaxOilTempTop);
 
-  mainCanvas.setCursor(10, 120);
+  mainCanvas.setCursor(10, 150);
 
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {


### PR DESCRIPTION
## English
Adjusted the Y positions of menu items to expand line spacing without overflowing the screen.

## 日本語
メニュー項目のY座標を変更して行間を広くしました。画面からはみ出さないよう調整しています。

------
https://chatgpt.com/codex/tasks/task_e_688caeb20e948322ad3070ba4e64aaf4