### PR TITLE
メニューでのMAX表示改善 / Show Disabled State for Max Values

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -227,16 +227,40 @@ void drawMenuScreen()
   mainCanvas.drawLine(LCD_WIDTH - 2, 1, LCD_WIDTH - 2, LCD_HEIGHT - 2, BORDER_DARK);
 
   mainCanvas.setCursor(10, 30);
-  // 数値部分を右寄せにし、インデントを揃える
-  mainCanvas.printf("OIL.P MAX: %6.1f", recordedMaxOilPressure);
+  // 油圧センサーが無効なら Disabled 表示
+  if (SENSOR_OIL_PRESSURE_PRESENT)
+  {
+    // 数値部分を右寄せにし、インデントを揃える
+    mainCanvas.printf("OIL.P MAX: %6.1f", recordedMaxOilPressure);
+  }
+  else
+  {
+    mainCanvas.printf("OIL.P MAX: Disabled");
+  }
 
   mainCanvas.setCursor(10, 60);
-  // こちらも同様に右寄せ表示
-  mainCanvas.printf("WATER.T MAX: %6.1f", recordedMaxWaterTemp);
+  // 水温センサーが無効なら Disabled 表示
+  if (SENSOR_WATER_TEMP_PRESENT)
+  {
+    // こちらも同様に右寄せ表示
+    mainCanvas.printf("WATER.T MAX: %6.1f", recordedMaxWaterTemp);
+  }
+  else
+  {
+    mainCanvas.printf("WATER.T MAX: Disabled");
+  }
 
   mainCanvas.setCursor(10, 90);
-  // 最大油温値を右寄せで表示
-  mainCanvas.printf("OIL.T MAX: %6d", recordedMaxOilTempTop);
+  // 油温センサーが無効なら Disabled 表示
+  if (SENSOR_OIL_TEMP_PRESENT)
+  {
+    // 最大油温値を右寄せで表示
+    mainCanvas.printf("OIL.T MAX: %6d", recordedMaxOilTempTop);
+  }
+  else
+  {
+    mainCanvas.printf("OIL.T MAX: Disabled");
+  }
 
   mainCanvas.setCursor(10, 120);
 


### PR DESCRIPTION
## Summary / 概要
- タッチメニューの最大値表示で、センサーが無効な場合に `Disabled` と表示するよう更新

## Testing / テスト
- `clang-format` と `clang-tidy` を実行
- `act -j build` はネットワーク制限により実行できず

------
https://chatgpt.com/codex/tasks/task_e_688cadf4136c83228f816ad1386fec87