### PR TITLE
画面クリアの追加 / Add screen clearing on menu exit

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -261,6 +261,10 @@ void drawMenuScreen()
 // ────────────────────── ゲージ状態リセット ──────────────────────
 void resetGaugeState()
 {
+  // メニュー画面の残像を防ぐため一度画面をクリアする
+  mainCanvas.fillScreen(COLOR_BLACK);
+  mainCanvas.pushSprite(0, 0);
+
   pressureGaugeInitialized = false;
   waterGaugeInitialized = false;
   prevPressureValue = std::numeric_limits<float>::quiet_NaN();


### PR DESCRIPTION
## 日本語
- メニューを閉じた際に `resetGaugeState()` で一度画面を黒で塗りつぶすようにしました。

## English
- Added a clear screen step in `resetGaugeState()` to avoid leftover menu graphics.


------
https://chatgpt.com/codex/tasks/task_e_688cb081b1c8832295caccf66ad09fc1