### PR TITLE
メニュー表示中の輝度最大化 / Max brightness during menu

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,7 +103,7 @@ void loop()
 
   M5.update();
 
-  if (now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
+  if (!isMenuVisible && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
   {
     updateBacklightLevel();
     lastAlsMeasurementTime = now;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,10 +116,14 @@ void loop()
     if (isMenuVisible)
     {
       drawMenuScreen();
+      // メニュー表示中は輝度を最大にする
+      display.setBrightness(BACKLIGHT_DAY);
     }
     else
     {
       resetGaugeState();
+      // メニュー終了後は照度センサーで再調整
+      updateBacklightLevel();
     }
   }
   wasTouched = touched;


### PR DESCRIPTION
## 日本語
メニュー画面を開いた際、輝度を最大に設定し、閉じた後に自動輝度制御を再実行するようにしました。

## English
When the menu is shown, the display brightness is forced to maximum. After closing the menu, brightness is adjusted again via the ambient light sensor.


------
https://chatgpt.com/codex/tasks/task_e_688cb8e7b34c8322a1e8aa6ff9947bd4