### PR TITLE
Handle water temperature >=199 like oil temp / 水温199度以上の処理修正

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -187,6 +187,13 @@ void updateGauges()
     oilPressureHighDurationMs += deltaMs;
   }
   float targetWaterTemp = calculateAverage(waterTemperatureSamples);
+  if (targetWaterTemp >= 199.0F)
+  {
+    // 199℃以上ならセンサー異常として扱い0を返す
+    targetWaterTemp = 0.0F;
+    recordedMaxWaterTemp = 0.0F;
+  }
+
   float targetOilTemp = calculateAverage(oilTemperatureSamples);
   if (targetOilTemp >= 199.0F)
   {


### PR DESCRIPTION
## Summary / 概要
- treat water temperature values of 199℃ and above as sensor errors, same as oil temperature

## Testing / テスト
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -- -Iinclude` (大量の警告が発生)
- `act -j build` (実行中にインタラクティブプロンプトが表示され中断)


------
https://chatgpt.com/codex/tasks/task_e_688ccd991be48322a3b5ec2ecedcb436