### PR TITLE
メニュー終了時に画面を黒でクリアして残像を防止 / Clear display on menu exit to prevent residual text

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -364,6 +364,7 @@ void drawMenuScreen()
 void resetGaugeState()
 {
   // メニュー画面の残像を防ぐため一度画面をクリアする
+  display.fillScreen(COLOR_BLACK);  // 実ディスプレイも黒で塗りつぶす
   mainCanvas.fillScreen(COLOR_BLACK);
   mainCanvas.pushSprite(0, 0);
 


### PR DESCRIPTION
## 概要 / Summary
- メニュー終了時に実ディスプレイを黒で塗りつぶす処理を追加し、画面の残像を解消

## テスト / Testing
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -- -std=c++17 -Isrc -Iinclude` (missing headerと多数のwarningで失敗)
- `./bin/act -j build` (Docker接続エラーで実行不可)


------
https://chatgpt.com/codex/tasks/task_e_688d89b49e4c8322ad421fd3e994458d