### PR TITLE
メニューからNOW表示を削除 / Remove NOW indicators from menu

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -266,15 +266,6 @@ void drawMenuScreen()
 
   y += 25;
   mainCanvas.setCursor(10, y);
-  mainCanvas.print("OIL.P NOW:");
-  {
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6.1f", displayCache.pressureAvg);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-
-  y += 25;
-  mainCanvas.setCursor(10, y);
   mainCanvas.print("WATER.T MAX:");
   {
     char valStr[8];
@@ -284,28 +275,10 @@ void drawMenuScreen()
 
   y += 25;
   mainCanvas.setCursor(10, y);
-  mainCanvas.print("WATER.T NOW:");
-  {
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6.1f", displayCache.waterTempAvg);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-
-  y += 25;
-  mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T MAX:");
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6d", recordedMaxOilTempTop);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-
-  y += 25;
-  mainCanvas.setCursor(10, y);
-  mainCanvas.print("OIL.T NOW:");
-  {
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6d", static_cast<int>(displayCache.oilTemp));
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
@@ -322,19 +295,12 @@ void drawMenuScreen()
   // 油温120度以上での経過時間を秒表示
   unsigned long oilTempSec = oilTempHighDurationMs / 1000UL;
   mainCanvas.printf("OIL.T Over 120 Sec: %lu", oilTempSec);
-  
+
   y += 25;
   mainCanvas.setCursor(10, y);
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {
-    // 現在値を表示
-    mainCanvas.print("LUX NOW:");
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6d", latestLux);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-
-    y += 25;
-    mainCanvas.setCursor(10, y);
+    // 照度の中央値のみ表示
     mainCanvas.print("LUX MEDIAN:");
     char medStr[8];
     snprintf(medStr, sizeof(medStr), "%6d", medianLuxValue);


### PR DESCRIPTION
## Summary / 概要
- メニュー画面のNOW表示を削除し、最大値と照度の中央値のみを表示
- Remove NOW indicators from the menu, leaving only MAX values and LUX median

## Testing / テスト
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp --` (header missing errors)
- `act -j build -P ubuntu-latest=catthehacker/ubuntu:act-latest` (Docker daemon not running)


------
https://chatgpt.com/codex/tasks/task_e_688d88d60f288322b6fcfbe02777b468