### PR TITLE
メニューでセンサー無効時にDisabledを表示 / Show "Disabled" when sensors are disabled in menu

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -251,6 +251,8 @@ void drawMenuScreen()
 
   // フラットデザインの枠を描く
   constexpr uint16_t BORDER_COLOR = rgb565(80, 80, 80);
+  // センサー無効時に表示する文字列
+  constexpr char DISABLED_STR[] = "Disabled";
   mainCanvas.drawRect(0, 0, LCD_WIDTH, LCD_HEIGHT, BORDER_COLOR);
 
   // 行間を詰めて縦幅を節約するため起点を少し上げる
@@ -267,7 +269,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -282,7 +284,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -297,7 +299,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -312,7 +314,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -327,7 +329,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -342,7 +344,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -361,7 +363,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -378,7 +380,7 @@ void drawMenuScreen()
   else
   {
     // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   y += 25;
@@ -402,12 +404,12 @@ void drawMenuScreen()
   {
     // LUX センサーが無い場合は両方 Disabled を表示
     mainCanvas.print("LUX NOW:");
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
 
     y += 25;
     mainCanvas.setCursor(10, y);
     mainCanvas.print("LUX MEDIAN:");
-    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
   }
 
   // 戻る案内を左下へ配置

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -258,76 +258,128 @@ void drawMenuScreen()
   mainCanvas.setCursor(10, y);
   // ラベルは左寄せ、値は右寄せで表示
   mainCanvas.print("OIL.P MAX:");
+  if (SENSOR_OIL_PRESSURE_PRESENT)
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxOilPressure);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.P NOW:");
+  if (SENSOR_OIL_PRESSURE_PRESENT)
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6.1f", displayCache.pressureAvg);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("WATER.T MAX:");
+  if (SENSOR_WATER_TEMP_PRESENT)
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxWaterTemp);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("WATER.T NOW:");
+  if (SENSOR_WATER_TEMP_PRESENT)
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6.1f", displayCache.waterTempAvg);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T MAX:");
+  if (SENSOR_OIL_TEMP_PRESENT)
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6d", recordedMaxOilTempTop);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T NOW:");
+  if (SENSOR_OIL_TEMP_PRESENT)
   {
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6d", static_cast<int>(displayCache.oilTemp));
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
-  unsigned long totalSec = oilPressureHighDurationMs / 1000UL;
-  unsigned int min = totalSec / 60U;
-  unsigned int sec = totalSec % 60U;
-  // OIL.Pが120以上だった時間を分秒で表示
   mainCanvas.print("OIL.P>120:");
-  char pressureStr[20];
-  snprintf(pressureStr, sizeof(pressureStr), "%02u min %02u sec", min, sec);
-  mainCanvas.drawRightString(pressureStr, LCD_WIDTH - 10, y);
+  if (SENSOR_OIL_PRESSURE_PRESENT)
+  {
+    // OIL.Pが120以上だった時間を分秒で表示
+    unsigned long totalSec = oilPressureHighDurationMs / 1000UL;
+    unsigned int min = totalSec / 60U;
+    unsigned int sec = totalSec % 60U;
+    char pressureStr[20];
+    snprintf(pressureStr, sizeof(pressureStr), "%02u min %02u sec", min, sec);
+    mainCanvas.drawRightString(pressureStr, LCD_WIDTH - 10, y);
+  }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
-  // 油温120度以上での経過時間を秒表示
-  unsigned long oilTempSec = oilTempHighDurationMs / 1000UL;
   mainCanvas.print("OIL.T>120 SEC:");
-  char oilTempStr[12];
-  snprintf(oilTempStr, sizeof(oilTempStr), "%lu", oilTempSec);
-  mainCanvas.drawRightString(oilTempStr, LCD_WIDTH - 10, y);
+  if (SENSOR_OIL_TEMP_PRESENT)
+  {
+    // 油温120度以上での経過時間を秒表示
+    unsigned long oilTempSec = oilTempHighDurationMs / 1000UL;
+    char oilTempStr[12];
+    snprintf(oilTempStr, sizeof(oilTempStr), "%lu", oilTempSec);
+    mainCanvas.drawRightString(oilTempStr, LCD_WIDTH - 10, y);
+  }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+  }
 
   y += 25;
   mainCanvas.setCursor(10, y);
@@ -348,7 +400,13 @@ void drawMenuScreen()
   }
   else
   {
-    mainCanvas.print("LUX:");
+    // LUX センサーが無い場合は両方 Disabled を表示
+    mainCanvas.print("LUX NOW:");
+    mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
+
+    y += 25;
+    mainCanvas.setCursor(10, y);
+    mainCanvas.print("LUX MEDIAN:");
     mainCanvas.drawRightString("Disabled", LCD_WIDTH - 10, y);
   }
 


### PR DESCRIPTION
## Summary / 概要
- センサー設定がfalseの場合、メニューで数値の代わりに"Disabled"を表示するよう修正
- LUXのNOW/MEDIAN項目もセンサー無効時に"Disabled"を表示

## Testing / テスト
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -- -Iinclude` (多数の警告とエラー)
- `act -j build -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest` (Dockerデーモンに接続できず失敗)


------
https://chatgpt.com/codex/tasks/task_e_688d88f2bfe48322a40268f4ca1e0efc