### PR TITLE
AGENTS.mdにcopilotレビュワー追加 / Add copilot reviewer instruction to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
   - 不具合修正: `fix/` プレフィックスを使用 / For bug fixes, use the `fix/` prefix.
   - リファクタ: `react/` プレフィックスを使用 / For refactoring, use the `react/` prefix.
 - プルリクエストのタイトルと概要は、日本語と英語の二言語で記述してください。/ Provide PR titles and descriptions in both Japanese and English.
+- プルリクエストを作成する際はレビュワーに `copilot` を追加してください。/ When creating a PR, add `copilot` as a reviewer.
 - コード中のコメントは日本語で記述してください。/ Write code comments in Japanese.
 - コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
 - 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.


### PR DESCRIPTION
## 概要 / Summary
- AGENTS.mdに、PR作成時にレビュワーとして`copilot`を追加する旨を追記 / Added instruction to AGENTS.md to assign `copilot` as a reviewer when creating PR

## テスト / Testing
- `clang-format -i $(git ls-files '*.h' '*.hpp' '*.c' '*.cpp' '*.cc' '*.hh')`
- `clang-tidy src/main.cpp --` (missing header `M5CoreS3.h`)


------
https://chatgpt.com/codex/tasks/task_e_688d94bb6e308322ac967aaf6e5e1cef