### PR TITLE
intelhexインストールステップを追加 / Add intelhex installation step

### DIFF
--- a/.github/workflows/pio-build.yml
+++ b/.github/workflows/pio-build.yml
@@ -44,6 +44,9 @@ jobs:
       - name: PlatformIO インストール
         run: pip install platformio
 
+      - name: intelhex インストール
+        run: pip install intelhex
+
       - name: ビルド
         run: pio run -e m5stack-cores3
 


### PR DESCRIPTION
## Summary / 概要
- PlatformIO インストール後に intelhex をインストールするステップを追加 / Add a step to install intelhex after installing PlatformIO

## Testing / テスト
- `act -j build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_688d9e8de294832282e6438306a77019