### PR TITLE
メニュー表示のはみ出しを修正 / Fix menu text overflow

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -245,8 +245,13 @@ void drawMenuScreen()
   constexpr uint16_t BORDER_COLOR = rgb565(80, 80, 80);
   mainCanvas.drawRect(0, 0, LCD_WIDTH, LCD_HEIGHT, BORDER_COLOR);
 
-  // 行間を詰めて縦幅を節約するため起点を少し上げる
-  int y = 25;
+  // 画面高さに合わせて行間を自動計算し、下にはみ出さないようにする
+  constexpr int MENU_TOP_MARGIN = 20;                                                       // 上端の余白
+  constexpr int MENU_BOTTOM_MARGIN = 40;                                                    // 下端の余白（戻る案内分）
+  constexpr int MENU_LINES = SENSOR_AMBIENT_LIGHT_PRESENT ? 7 : 6;                          // 表示行数
+  const int lineHeight = (LCD_HEIGHT - MENU_TOP_MARGIN - MENU_BOTTOM_MARGIN) / MENU_LINES;  // 行間
+
+  int y = MENU_TOP_MARGIN;
   mainCanvas.setCursor(10, y);
   // ラベルは左寄せ、値は右寄せで表示
   mainCanvas.print("OIL.P MAX:");
@@ -256,7 +261,7 @@ void drawMenuScreen()
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
-  y += 25;
+  y += lineHeight;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("WATER.T MAX:");
   {
@@ -265,7 +270,7 @@ void drawMenuScreen()
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
-  y += 25;
+  y += lineHeight;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T MAX:");
   {
@@ -274,7 +279,7 @@ void drawMenuScreen()
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
-  y += 25;
+  y += lineHeight;
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T NOW:");
   {
@@ -283,7 +288,7 @@ void drawMenuScreen()
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
 
-  y += 25;
+  y += lineHeight;
   mainCanvas.setCursor(10, y);
   // 油温120度以上での経過時間を秒表示
   unsigned long oilTempSec = oilTempHighDurationMs / 1000UL;
@@ -292,8 +297,7 @@ void drawMenuScreen()
   snprintf(oilTempStr, sizeof(oilTempStr), "%lu", oilTempSec);
   mainCanvas.drawRightString(oilTempStr, LCD_WIDTH - 10, y);
 
-
-  y += 25;
+  y += lineHeight;
   mainCanvas.setCursor(10, y);
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {
@@ -303,7 +307,7 @@ void drawMenuScreen()
     snprintf(valStr, sizeof(valStr), "%6d", latestLux);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
 
-    y += 25;
+    y += lineHeight;
     mainCanvas.setCursor(10, y);
     // 照度の中央値を表示
     mainCanvas.print("LUX MEDIAN:");


### PR DESCRIPTION
## 概要 / Summary
- メニューの行間を画面高さに合わせて自動調整し、文字が下にはみ出る問題を修正

## テスト / Testing
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -- -Iinclude` (警告により失敗)
- `./bin/act -j build` (デフォルトイメージ選択待ちで停止)

------
https://chatgpt.com/codex/tasks/task_e_688d9e88b6988322b841884fc7709718