### PR TITLE
デモモードでADC未接続エラーを無効化 / Disable ADC error in demo mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,8 +76,8 @@ void setup()
       M5.Lcd.setTextSize(2);
       M5.Lcd.setTextColor(COLOR_RED);
       M5.Lcd.setCursor(0, 0);
-      M5.Lcd.println("ADS1015初期化失敗");
-      M5.Lcd.println("配線を確認してください");
+      M5.Lcd.println("ADS1015 init failed");
+      M5.Lcd.println("Check wiring");
     }
     else
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,11 +67,23 @@ void setup()
   pinMode(8, INPUT_PULLUP);
   Wire.begin(9, 8);
 
-  if (!adsConverter.begin())
+  if (!DEMO_MODE_ENABLED)
   {
-    Serial.println("[ADS1015] init failed… all analog values will be 0");
+    // デモモードでなければADS1015を初期化し、失敗時は画面にエラーを表示
+    if (!adsConverter.begin())
+    {
+      Serial.println("[ADS1015] init failed… all analog values will be 0");
+      M5.Lcd.setTextSize(2);
+      M5.Lcd.setTextColor(COLOR_RED);
+      M5.Lcd.setCursor(0, 0);
+      M5.Lcd.println("ADS1015初期化失敗");
+      M5.Lcd.println("配線を確認してください");
+    }
+    else
+    {
+      adsConverter.setDataRate(RATE_ADS1015_1600SPS);
+    }
   }
-  adsConverter.setDataRate(RATE_ADS1015_1600SPS);
 
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {


### PR DESCRIPTION
## 概要 / Summary
- デモモード以外でADS1015初期化に失敗した場合、画面にエラーと配線確認のメッセージを表示

## テスト / Testing
- `clang-format -i src/main.cpp`
- `clang-tidy src/main.cpp -- -Iinclude -Ilib/M5CoreS3/src -Ilib/M5Unified/src -Ilib/M5GFX/src -std=c++17` (FreeRTOS 依存の型が見つからず失敗)
- `act -j build` (Docker が無く、実行に失敗)


------
https://chatgpt.com/codex/tasks/task_e_688d9e256314832281a861a8caf03cb1