### PR TITLE
OIL.T NOWの表示削除 / Remove OIL.T NOW display

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -293,21 +293,6 @@ void drawMenuScreen()
 
   y += lineHeight;
   mainCanvas.setCursor(10, y);
-  mainCanvas.print("OIL.T NOW:");
-  if (SENSOR_OIL_TEMP_PRESENT)
-  {
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6d", static_cast<int>(displayCache.oilTemp));
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-  else
-  {
-    // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
-  }
-
-  y += lineHeight;
-  mainCanvas.setCursor(10, y);
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {
     // 現在のLUX値を表示


### PR DESCRIPTION
## Summary
- "OIL.T NOW" 表示行をメニューから削除 / Remove "OIL.T NOW" line from the menu

## Testing
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -- -Iinclude` (missing headers, many warnings)
- `act -j build` (no Docker connection)

------
https://chatgpt.com/codex/tasks/task_e_688de95302a48322a451157f2b7aa5a4