### PR TITLE
タッチ2回目で油圧グラフ表示機能を追加 / Add oil pressure graph on second touch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,15 @@ int fpsFrameCounter = 0;
 int currentFps = 0;
 unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
 unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
-bool isMenuVisible = false;         // メニュー表示中かどうか
-static bool wasTouched = false;     // 前回タッチされていたか
+// 画面表示状態
+enum class DisplayMode
+{
+  GAUGE,          // 通常ゲージ
+  MENU,           // メニュー
+  PRESSURE_GRAPH  // 油圧グラフ
+};
+DisplayMode displayMode = DisplayMode::GAUGE;
+static bool wasTouched = false;  // 前回タッチされていたか
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -115,7 +122,7 @@ void loop()
 
   M5.update();
 
-  if (!isMenuVisible && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
+  if (displayMode == DisplayMode::GAUGE && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
   {
     updateBacklightLevel();
     lastAlsMeasurementTime = now;
@@ -124,26 +131,40 @@ void loop()
   bool touched = M5.Touch.getCount() > 0;
   if (touched && !wasTouched)
   {
-    isMenuVisible = !isMenuVisible;
-    if (isMenuVisible)
+    // タッチごとに表示状態を切り替える
+    switch (displayMode)
     {
-      drawMenuScreen();
-      // メニュー表示中は輝度を最大にする
-      display.setBrightness(BACKLIGHT_DAY);
-    }
-    else
-    {
-      resetGaugeState();
-      // メニュー終了後は照度センサーで再調整
-      updateBacklightLevel();
+      case DisplayMode::GAUGE:
+        displayMode = DisplayMode::MENU;
+        drawMenuScreen();
+        // メニュー表示中は輝度を最大にする
+        display.setBrightness(BACKLIGHT_DAY);
+        break;
+      case DisplayMode::MENU:
+        displayMode = DisplayMode::PRESSURE_GRAPH;
+        // グラフ初期表示
+        drawPressureGraph();
+        break;
+      case DisplayMode::PRESSURE_GRAPH:
+        displayMode = DisplayMode::GAUGE;
+        resetGaugeState();
+        // ゲージ表示に戻ったら照度で輝度調整
+        updateBacklightLevel();
+        break;
     }
   }
   wasTouched = touched;
 
   acquireSensorData();
-  if (!isMenuVisible)
+  // 油圧ログを更新
+  logOilPressure();
+  if (displayMode == DisplayMode::GAUGE)
   {
     updateGauges();
+  }
+  else if (displayMode == DisplayMode::PRESSURE_GRAPH)
+  {
+    drawPressureGraph();
   }
 
   fpsFrameCounter++;

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -15,5 +15,8 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
 void updateGauges();
 void drawMenuScreen();
 void resetGaugeState();
+// 油圧ログ追加とグラフ描画
+void logOilPressure();
+void drawPressureGraph();
 
 #endif  // DISPLAY_H


### PR DESCRIPTION
## Summary
- 2回目のタッチで油圧グラフを表示し、通常ゲージ・メニュー・グラフを切り替え可能にしました
- 油圧を30分間ログし、時間を横軸としたスクロールグラフを描画する機能を追加しました

## Testing
- `clang-format -i src/main.cpp src/modules/display.cpp src/modules/display.h`
- `clang-tidy src/main.cpp src/modules/display.cpp src/modules/display.h -p .` *(failed: Could not auto-detect compilation database)*
- `act -j build` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688dea014a508322bc146b1ff9ab591a