### PR TITLE
タッチ後1分で画面を自動復帰 / Auto-return screen after 1 minute of touch

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -80,6 +80,9 @@ constexpr int MEDIAN_BUFFER_SIZE = 6;
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;
 
+// メニューが自動的に閉じるまでの時間 [ms]
+constexpr unsigned long MENU_TIMEOUT_MS = 60000UL;
+
 // 最大60FPSに制御するためのフレーム間隔 [us]
 constexpr unsigned long FRAME_INTERVAL_US = 1000000UL / 60;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,10 +11,11 @@
 unsigned long lastFpsSecond = 0;  // 直近1秒判定用
 int fpsFrameCounter = 0;
 int currentFps = 0;
-unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
-unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
-bool isMenuVisible = false;         // メニュー表示中かどうか
-static bool wasTouched = false;     // 前回タッチされていたか
+unsigned long lastDebugPrint = 0;        // デバッグ表示用タイマー
+unsigned long lastFrameTimeUs = 0;       // 前回フレーム開始時刻
+bool isMenuVisible = false;              // メニュー表示中かどうか
+static bool wasTouched = false;          // 前回タッチされていたか
+static unsigned long lastTouchTime = 0;  // 最終タッチ時刻
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -122,6 +123,10 @@ void loop()
   }
 
   bool touched = M5.Touch.getCount() > 0;
+  if (touched)
+  {
+    lastTouchTime = now;  // タッチ時刻を記録
+  }
   if (touched && !wasTouched)
   {
     isMenuVisible = !isMenuVisible;
@@ -139,6 +144,14 @@ void loop()
     }
   }
   wasTouched = touched;
+
+  // 一定時間タッチがない場合はメニューを自動で閉じる
+  if (isMenuVisible && (now - lastTouchTime >= MENU_TIMEOUT_MS))
+  {
+    isMenuVisible = false;
+    resetGaugeState();
+    updateBacklightLevel();
+  }
 
   acquireSensorData();
   if (!isMenuVisible)


### PR DESCRIPTION
## Summary
- メニュー表示後に1分操作が無い場合は自動的に計測画面へ戻るようにしました
- Added automatic return to gauge screen when no input occurs for 1 minute after touch

## Testing
- `clang-format -i include/config.h src/main.cpp`
- `clang-tidy src/main.cpp -- -Iinclude -Isrc` *(header missing: M5CoreS3.h)*
- `act -j build` *(failed: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_688de9396b6c832288f666b7060f8ed1