### PR TITLE
油圧グラフを三段表示で10・20・30分前を表示 / Show oil pressure graph in three segments for 10, 20, 30 minutes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,15 @@ int fpsFrameCounter = 0;
 int currentFps = 0;
 unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
 unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
-bool isMenuVisible = false;         // メニュー表示中かどうか
-static bool wasTouched = false;     // 前回タッチされていたか
+// 画面表示状態
+enum class DisplayMode
+{
+  GAUGE,          // 通常ゲージ
+  MENU,           // メニュー
+  PRESSURE_GRAPH  // 油圧グラフ
+};
+DisplayMode displayMode = DisplayMode::GAUGE;
+static bool wasTouched = false;  // 前回タッチされていたか
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -115,7 +122,7 @@ void loop()
 
   M5.update();
 
-  if (!isMenuVisible && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
+  if (displayMode == DisplayMode::GAUGE && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
   {
     updateBacklightLevel();
     lastAlsMeasurementTime = now;
@@ -124,26 +131,40 @@ void loop()
   bool touched = M5.Touch.getCount() > 0;
   if (touched && !wasTouched)
   {
-    isMenuVisible = !isMenuVisible;
-    if (isMenuVisible)
+    // タッチごとに表示状態を切り替える
+    switch (displayMode)
     {
-      drawMenuScreen();
-      // メニュー表示中は輝度を最大にする
-      display.setBrightness(BACKLIGHT_DAY);
-    }
-    else
-    {
-      resetGaugeState();
-      // メニュー終了後は照度センサーで再調整
-      updateBacklightLevel();
+      case DisplayMode::GAUGE:
+        displayMode = DisplayMode::MENU;
+        drawMenuScreen();
+        // メニュー表示中は輝度を最大にする
+        display.setBrightness(BACKLIGHT_DAY);
+        break;
+      case DisplayMode::MENU:
+        displayMode = DisplayMode::PRESSURE_GRAPH;
+        // グラフ初期表示
+        drawPressureGraph();
+        break;
+      case DisplayMode::PRESSURE_GRAPH:
+        displayMode = DisplayMode::GAUGE;
+        resetGaugeState();
+        // ゲージ表示に戻ったら照度で輝度調整
+        updateBacklightLevel();
+        break;
     }
   }
   wasTouched = touched;
 
   acquireSensorData();
-  if (!isMenuVisible)
+  // 油圧ログを更新
+  logOilPressure();
+  if (displayMode == DisplayMode::GAUGE)
   {
     updateGauges();
+  }
+  else if (displayMode == DisplayMode::PRESSURE_GRAPH)
+  {
+    drawPressureGraph();
   }
 
   fpsFrameCounter++;

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -22,6 +22,13 @@ int recordedMaxOilTempTop = 0;
 // 前回の油圧測定時刻
 static unsigned long lastPressureCheckMs = 0;
 
+// ── 油圧ログ用バッファ ──
+constexpr int PRESSURE_LOG_SECONDS = 30 * 60;  // 30分のログ
+static float oilPressureLog[PRESSURE_LOG_SECONDS] = {};
+static int oilPressureLogIndex = 0;
+static int oilPressureLogCount = 0;
+static unsigned long lastPressureLogTime = 0;
+
 // 前回描画したゲージ値
 static float prevPressureValue = std::numeric_limits<float>::quiet_NaN();
 static float prevWaterTempValue = std::numeric_limits<float>::quiet_NaN();
@@ -357,4 +364,81 @@ void resetGaugeState()
   prevWaterTempValue = std::numeric_limits<float>::quiet_NaN();
   displayCache = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
                   std::numeric_limits<float>::quiet_NaN(), INT16_MIN};
+}
+
+// ────────────────────── 油圧ログ追加 ──────────────────────
+void logOilPressure()
+{
+  unsigned long now = millis();
+  if (now - lastPressureLogTime >= 1000)
+  {
+    // 最新の油圧平均値を取得しログへ保存
+    float pressure = calculateAverage(oilPressureSamples);
+    oilPressureLog[oilPressureLogIndex] = pressure;
+    oilPressureLogIndex = (oilPressureLogIndex + 1) % PRESSURE_LOG_SECONDS;
+    if (oilPressureLogCount < PRESSURE_LOG_SECONDS)
+    {
+      oilPressureLogCount++;
+    }
+    lastPressureLogTime = now;
+  }
+}
+
+// ────────────────────── 油圧グラフ描画 ──────────────────────
+void drawPressureGraph()
+{
+  mainCanvas.fillScreen(COLOR_BLACK);
+
+  const int width = LCD_WIDTH;
+  const int height = LCD_HEIGHT;
+  const int sectionCount = 3;
+  const int sectionHeight = height / sectionCount;
+  const int windowSeconds = 10 * 60;  // 各段は10分を表示
+
+  mainCanvas.setTextColor(COLOR_WHITE);
+  // 縦軸ラベル
+  mainCanvas.setCursor(5, 5);
+  mainCanvas.print("油圧 / bar");
+
+  for (int s = 0; s < sectionCount; ++s)
+  {
+    // 古い段から新しい段へ並べるためオフセットを計算
+    int offset = (sectionCount - 1 - s) * windowSeconds;
+    int available = oilPressureLogCount - offset;
+    if (available <= 0) continue;  // データ不足なら描画しない
+
+    int samplesToDraw = std::min(windowSeconds, available);
+    int start = (oilPressureLogIndex - offset - samplesToDraw + PRESSURE_LOG_SECONDS) % PRESSURE_LOG_SECONDS;
+    int yBase = (s + 1) * sectionHeight - 1;
+
+    // 軸を描画
+    mainCanvas.drawLine(0, yBase, width, yBase, COLOR_WHITE);
+    mainCanvas.drawLine(0, yBase - sectionHeight + 1, 0, yBase, COLOR_WHITE);
+
+    // 段のラベルを表示（例: 10分前, 20分前, 30分前）
+    mainCanvas.setCursor(5, yBase - sectionHeight + 5);
+    mainCanvas.printf("%d分前", (sectionCount - s) * 10);
+
+    float samplesPerPixel = static_cast<float>(samplesToDraw) / width;
+    int prevX = 0;
+    float firstP = oilPressureLog[start % PRESSURE_LOG_SECONDS];
+    int prevY = yBase - static_cast<int>((firstP / MAX_OIL_PRESSURE_DISPLAY) * (sectionHeight - 1));
+
+    for (int x = 1; x < width; ++x)
+    {
+      int sampleIndex = start + static_cast<int>(x * samplesPerPixel);
+      if (sampleIndex >= start + samplesToDraw) break;
+      float p = oilPressureLog[sampleIndex % PRESSURE_LOG_SECONDS];
+      int y = yBase - static_cast<int>((p / MAX_OIL_PRESSURE_DISPLAY) * (sectionHeight - 1));
+      mainCanvas.drawLine(prevX, prevY, x, y, COLOR_YELLOW);
+      prevX = x;
+      prevY = y;
+    }
+  }
+
+  // 横軸ラベル
+  mainCanvas.setCursor(width - 40, height - 15);
+  mainCanvas.print("時間");
+
+  mainCanvas.pushSprite(0, 0);
 }

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -15,5 +15,8 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
 void updateGauges();
 void drawMenuScreen();
 void resetGaugeState();
+// 油圧ログ追加とグラフ描画
+void logOilPressure();
+void drawPressureGraph();
 
 #endif  // DISPLAY_H


### PR DESCRIPTION
## Summary
- 油圧グラフを三段表示にし、10・20・30分前のデータを確認できるようにしました
- Split oil pressure graph into three sections showing data from 10, 20, and 30 minutes ago

## Testing
- `clang-format -i src/main.cpp src/modules/display.cpp src/modules/display.h`
- `clang-tidy src/main.cpp src/modules/display.cpp src/modules/display.h -p .` *(failed: Could not auto-detect compilation database)*
- `act -j build` *(failed: command not found; attempted apt install but package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dea014a508322bc146b1ff9ab591a