### PR TITLE
fix: add low oil pressure warning / 低油圧警告の追加

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,8 +22,9 @@ static void printSensorDebugInfo()
   float pressure = calculateAverage(oilPressureSamples);
   float water = calculateAverage(waterTemperatureSamples);
   float oil = calculateAverage(oilTemperatureSamples);
-  // 横Gと各センサー値をシリアルに表示
-  Serial.printf("G: %.2f, Oil.P: %.2f bar, Water.T: %.1f C, Oil.T: %.1f C\n", currentGForce, pressure, water, oil);
+  // 水平Gと各センサー値をシリアルに表示
+  Serial.printf("G: %.2f%c, Oil.P: %.2f bar, Water.T: %.1f C, Oil.T: %.1f C\n", currentGForce, currentGDirection, pressure,
+                water, oil);
 }
 
 // ────────────────────── setup() ──────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,8 @@ static void printSensorDebugInfo()
   float pressure = calculateAverage(oilPressureSamples);
   float water = calculateAverage(waterTemperatureSamples);
   float oil = calculateAverage(oilTemperatureSamples);
-  Serial.printf("Oil.P: %.2f bar, Water.T: %.1f C, Oil.T: %.1f C\n", pressure, water, oil);
+  // 横Gと各センサー値をシリアルに表示
+  Serial.printf("G: %.2f, Oil.P: %.2f bar, Water.T: %.1f C, Oil.T: %.1f C\n", currentGForce, pressure, water, oil);
 }
 
 // ────────────────────── setup() ──────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ void setup()
   M5.Lcd.fillScreen(COLOR_BLACK);
 
   // M5.Speaker.begin();  // スピーカーを使用しないため無効化
-  // M5.Imu.begin();      // IMU を使用しないため無効化
+  M5.Imu.begin();  // IMU を使用
   btStop();
 
   pinMode(9, INPUT_PULLUP);

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -54,8 +54,8 @@ static bool drawLowPressureWarning(M5Canvas& canvas, float gForce, float pressur
   int boxX = GAUGE_X + ((GAUGE_W - boxW) / 2);
   int boxY = GAUGE_Y + ((GAUGE_H - boxH) / 2);
 
-  // 静止状態でも1Gを検出するため1.5G以上で判定
-  constexpr float G_FORCE_THRESHOLD = 1.5F;          // G判定値（静止1Gを考慮）
+  // 横Gが1G以上で判定
+  constexpr float G_FORCE_THRESHOLD = 1.0F;          // G判定値
   constexpr float PRESSURE_THRESHOLD = 3.0F;         // 油圧閾値
   constexpr unsigned long WARNING_DELAY_MS = 500UL;  // 継続時間
   bool conditionMet = (gForce >= G_FORCE_THRESHOLD && pressure <= PRESSURE_THRESHOLD);

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -54,10 +54,10 @@ static bool drawLowPressureWarning(M5Canvas& canvas, float gForce, float pressur
   int boxX = GAUGE_X + ((GAUGE_W - boxW) / 2);
   int boxY = GAUGE_Y + ((GAUGE_H - boxH) / 2);
 
-  constexpr float G_FORCE_THRESHOLD = 1.0F;          // G判定値
+  constexpr float G_FORCE_THRESHOLD = 0.5F;          // G判定値
   constexpr float PRESSURE_THRESHOLD = 3.0F;         // 油圧閾値
   constexpr unsigned long WARNING_DELAY_MS = 500UL;  // 継続時間
-  bool conditionMet = (gForce > G_FORCE_THRESHOLD && pressure <= PRESSURE_THRESHOLD);
+  bool conditionMet = (gForce >= G_FORCE_THRESHOLD && pressure <= PRESSURE_THRESHOLD);
   static unsigned long startMs = 0;  // 条件成立開始時刻
   static bool isShowing = false;
   unsigned long now = millis();

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -8,6 +8,7 @@
 #include "DrawFillArcMeter.h"
 #include "backlight.h"
 #include "fps_display.h"
+#include "low_warning.h"
 #include "sensor.h"
 
 // ────────────────────── グローバル変数 ──────────────────────
@@ -35,109 +36,6 @@ struct DisplayCache
   int16_t maxOilTemp;
 } displayCache = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
                   std::numeric_limits<float>::quiet_NaN(), INT16_MIN};
-
-// 直近の低油圧イベント情報
-float lastLowEventG = 0.0F;         // 発生時のG値
-char lastLowEventDir = 'R';         // Gの向き
-float lastLowEventDuration = 0.0F;  // 継続時間[s]
-float lastLowEventPressure = 0.0F;  // そのときの油圧[bar]
-
-// 油圧警告表示。現在の表示状態とその変更の有無を返す
-static bool drawLowPressureWarning(M5Canvas& canvas, float gForce, float pressure, bool& stateChanged)
-{
-  // ゲージ位置とサイズ
-  constexpr int GAUGE_X = 0;    // 油圧ゲージの左上X
-  constexpr int GAUGE_Y = 60;   // 油圧ゲージの左上Y
-  constexpr int GAUGE_W = 160;  // ゲージ幅
-  constexpr int GAUGE_H = 170;  // ゲージ高さ
-
-  canvas.setFont(&fonts::FreeSansBold12pt7b);
-  // 警告文字列を生成（例: G2.3L）
-  char warnStr[16];
-  snprintf(warnStr, sizeof(warnStr), "G%.1f%c", gForce, currentGDirection);
-  int textW = canvas.textWidth(warnStr);
-  int textH = canvas.fontHeight();
-  constexpr int PADDING = 4;  // ボックス余白
-  int boxW = textW + (PADDING * 2);
-  int boxH = textH + (PADDING * 2);
-  int boxX = GAUGE_X + ((GAUGE_W - boxW) / 2);
-  int boxY = GAUGE_Y + ((GAUGE_H - boxH) / 2);
-  static int lastBoxX = boxX;  // 最後に描画したボックス座標
-  static int lastBoxY = boxY;
-  static int lastBoxW = boxW;
-  static int lastBoxH = boxH;
-
-  // 横Gが1G以上で判定
-  constexpr float G_FORCE_THRESHOLD = 1.0F;          // G判定値
-  constexpr float PRESSURE_THRESHOLD = 3.0F;         // 油圧閾値
-  constexpr unsigned long WARNING_DELAY_MS = 500UL;  // 継続時間
-  bool conditionMet = (gForce >= G_FORCE_THRESHOLD && pressure <= PRESSURE_THRESHOLD);
-  static unsigned long startMs = 0;  // 条件成立開始時刻
-  static bool isShowing = false;
-  static float peakG = 0.0F;                                     // 期間中の最大G
-  static float minPressure = std::numeric_limits<float>::max();  // 期間中の最低油圧
-  static char eventDir = 'R';                                    // 発生方向
-  unsigned long now = millis();
-  bool shouldShow = false;
-
-  if (conditionMet)
-  {
-    if (startMs == 0)
-    {
-      startMs = now;
-      peakG = gForce;
-      minPressure = pressure;
-      eventDir = currentGDirection;
-    }
-    else
-    {
-      peakG = std::max(peakG, gForce);
-      minPressure = std::min(minPressure, pressure);
-    }
-    if (now - startMs >= WARNING_DELAY_MS)
-    {
-      // 0.5秒以上継続したら警告表示
-      // サイズ変化に対応するため以前のボックスを消去
-      if (isShowing)
-      {
-        canvas.fillRect(lastBoxX, lastBoxY, lastBoxW, lastBoxH, COLOR_BLACK);
-      }
-      // 赤背景に方向付きG値を表示
-      canvas.fillRect(boxX, boxY, boxW, boxH, COLOR_RED);
-      canvas.setTextColor(COLOR_WHITE, COLOR_RED);
-      canvas.setCursor(boxX + ((boxW - textW) / 2), boxY + ((boxH - textH) / 2));
-      canvas.print(warnStr);
-      // 消去用にボックス位置とサイズを保持
-      lastBoxX = boxX;
-      lastBoxY = boxY;
-      lastBoxW = boxW;
-      lastBoxH = boxH;
-      shouldShow = true;
-    }
-  }
-  else
-  {
-    // 条件外になったらタイマーをリセットし、表示していれば消去
-    if (startMs != 0)
-    {
-      // 条件解除時にイベント情報を記録
-      lastLowEventG = peakG;
-      lastLowEventDir = eventDir;
-      lastLowEventDuration = (now - startMs) / 1000.0F;
-      lastLowEventPressure = minPressure;
-    }
-    startMs = 0;
-    if (isShowing)
-    {
-      // 直前に描画した領域を完全に消去
-      canvas.fillRect(lastBoxX, lastBoxY, lastBoxW, lastBoxH, COLOR_BLACK);
-    }
-  }
-
-  stateChanged = (shouldShow != isShowing);
-  isShowing = shouldShow;
-  return shouldShow;
-}
 
 // ────────────────────── 油温バー描画 ──────────────────────
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -54,7 +54,8 @@ static bool drawLowPressureWarning(M5Canvas& canvas, float gForce, float pressur
   int boxX = GAUGE_X + ((GAUGE_W - boxW) / 2);
   int boxY = GAUGE_Y + ((GAUGE_H - boxH) / 2);
 
-  constexpr float G_FORCE_THRESHOLD = 0.5F;          // G判定値
+  // 静止状態でも1Gを検出するため1.5G以上で判定
+  constexpr float G_FORCE_THRESHOLD = 1.5F;          // G判定値（静止1Gを考慮）
   constexpr float PRESSURE_THRESHOLD = 3.0F;         // 油圧閾値
   constexpr unsigned long WARNING_DELAY_MS = 500UL;  // 継続時間
   bool conditionMet = (gForce >= G_FORCE_THRESHOLD && pressure <= PRESSURE_THRESHOLD);

--- a/src/modules/low_warning.cpp
+++ b/src/modules/low_warning.cpp
@@ -1,0 +1,112 @@
+#include "low_warning.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+#include "config.h"
+#include "sensor.h"
+
+// 直近の低油圧イベント情報
+float lastLowEventG = 0.0F;         // 発生時のG値
+char lastLowEventDir = 'R';         // Gの向き
+float lastLowEventDuration = 0.0F;  // 継続時間[s]
+float lastLowEventPressure = 0.0F;  // そのときの油圧[bar]
+
+// 油圧警告表示。現在の表示状態とその変更の有無を返す
+bool drawLowPressureWarning(M5Canvas &canvas, float gForce, float pressure, bool &stateChanged)
+{
+  // ゲージ位置とサイズ
+  constexpr int GAUGE_X = 0;    // 油圧ゲージの左上X
+  constexpr int GAUGE_Y = 60;   // 油圧ゲージの左上Y
+  constexpr int GAUGE_W = 160;  // ゲージ幅
+  constexpr int GAUGE_H = 170;  // ゲージ高さ
+
+  canvas.setFont(&fonts::FreeSansBold12pt7b);
+  // 警告文字列を生成（例: G2.3L）
+  char warnStr[16];
+  snprintf(warnStr, sizeof(warnStr), "G%.1f%c", gForce, currentGDirection);
+  int textW = canvas.textWidth(warnStr);
+  int textH = canvas.fontHeight();
+  constexpr int PADDING = 4;  // ボックス余白
+  int boxW = textW + (PADDING * 2);
+  int boxH = textH + (PADDING * 2);
+  int boxX = GAUGE_X + ((GAUGE_W - boxW) / 2);
+  int boxY = GAUGE_Y + ((GAUGE_H - boxH) / 2);
+  static int lastBoxX = boxX;  // 最後に描画したボックス座標
+  static int lastBoxY = boxY;
+  static int lastBoxW = boxW;
+  static int lastBoxH = boxH;
+
+  // 横Gが1G以上で判定
+  constexpr float G_FORCE_THRESHOLD = 1.0F;          // G判定値
+  constexpr float PRESSURE_THRESHOLD = 3.0F;         // 油圧閾値
+  constexpr unsigned long WARNING_DELAY_MS = 500UL;  // 継続時間
+  bool conditionMet = (gForce >= G_FORCE_THRESHOLD && pressure <= PRESSURE_THRESHOLD);
+  static unsigned long startMs = 0;  // 条件成立開始時刻
+  static bool isShowing = false;
+  static float peakG = 0.0F;                                     // 期間中の最大G
+  static float minPressure = std::numeric_limits<float>::max();  // 期間中の最低油圧
+  static char eventDir = 'R';                                    // 発生方向
+  unsigned long now = millis();
+  bool shouldShow = false;
+
+  if (conditionMet)
+  {
+    if (startMs == 0)
+    {
+      startMs = now;
+      peakG = gForce;
+      minPressure = pressure;
+      eventDir = currentGDirection;
+    }
+    else
+    {
+      peakG = std::max(peakG, gForce);
+      minPressure = std::min(minPressure, pressure);
+    }
+    if (now - startMs >= WARNING_DELAY_MS)
+    {
+      // 0.5秒以上継続したら警告表示
+      // サイズ変化に対応するため以前のボックスを消去
+      if (isShowing)
+      {
+        canvas.fillRect(lastBoxX, lastBoxY, lastBoxW, lastBoxH, COLOR_BLACK);
+      }
+      // 赤背景に方向付きG値を表示
+      canvas.fillRect(boxX, boxY, boxW, boxH, COLOR_RED);
+      canvas.setTextColor(COLOR_WHITE, COLOR_RED);
+      canvas.setCursor(boxX + ((boxW - textW) / 2), boxY + ((boxH - textH) / 2));
+      canvas.print(warnStr);
+      // 消去用にボックス位置とサイズを保持
+      lastBoxX = boxX;
+      lastBoxY = boxY;
+      lastBoxW = boxW;
+      lastBoxH = boxH;
+      shouldShow = true;
+    }
+  }
+  else
+  {
+    // 条件外になったらタイマーをリセットし、表示していれば消去
+    if (startMs != 0)
+    {
+      // 条件解除時にイベント情報を記録
+      lastLowEventG = peakG;
+      lastLowEventDir = eventDir;
+      lastLowEventDuration = (now - startMs) / 1000.0F;
+      lastLowEventPressure = minPressure;
+    }
+    startMs = 0;
+    if (isShowing)
+    {
+      // 直前に描画した領域を完全に消去
+      canvas.fillRect(lastBoxX, lastBoxY, lastBoxW, lastBoxH, COLOR_BLACK);
+    }
+  }
+
+  stateChanged = (shouldShow != isShowing);
+  isShowing = shouldShow;
+  return shouldShow;
+}

--- a/src/modules/low_warning.h
+++ b/src/modules/low_warning.h
@@ -1,0 +1,15 @@
+#ifndef LOW_WARNING_H
+#define LOW_WARNING_H
+
+#include <M5GFX.h>
+
+// 直近の低油圧イベント情報
+extern float lastLowEventG;         // 発生時のG値
+extern char lastLowEventDir;        // Gの向き
+extern float lastLowEventDuration;  // 継続時間[s]
+extern float lastLowEventPressure;  // そのときの油圧[bar]
+
+// 低油圧警告表示。現在の表示状態とその変更の有無を返す
+bool drawLowPressureWarning(M5Canvas &canvas, float gForce, float pressure, bool &stateChanged);
+
+#endif  // LOW_WARNING_H

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -1,5 +1,6 @@
 #include "sensor.h"
 
+#include <M5CoreS3.h>
 #include <Wire.h>
 
 #include <algorithm>
@@ -13,6 +14,7 @@ float oilPressureSamples[PRESSURE_SAMPLE_SIZE] = {};
 float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE] = {};
 float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE] = {};
 bool oilPressureOverVoltage = false;
+float currentGForce = 0.0F;
 static int oilPressureIndex = 0;
 static int waterTempIndex = 0;
 static int oilTempIndex = 0;
@@ -129,6 +131,11 @@ void acquireSensorData()
                                   1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 0.0F, 0.0F, 2.5F};
 
   unsigned long now = millis();
+
+  // IMU から加速度を取得し合成値を計算
+  float ax = 0.0F, ay = 0.0F, az = 0.0F;
+  M5.Imu.getAccelData(&ax, &ay, &az);
+  currentGForce = sqrtf(ax * ax + ay * ay + az * az);
 
   // デモモード処理
   if (DEMO_MODE_ENABLED)

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -207,7 +207,7 @@ void acquireSensorData()
   {
     currentGForce = absVals[longitudinalAxis];
     float val = (longitudinalAxis == 0) ? adjX : (longitudinalAxis == 1) ? adjY : adjZ;
-    currentGDirection = (val >= 0.0F) ? 'F' : 'R';
+    currentGDirection = (val >= 0.0F) ? 'F' : 'B';  // 前後方向の判定
   }
 
   // デモモード処理

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -135,7 +135,9 @@ void acquireSensorData()
   // IMU から加速度を取得し合成値を計算
   float ax = 0.0F, ay = 0.0F, az = 0.0F;
   M5.Imu.getAccelData(&ax, &ay, &az);
-  currentGForce = sqrtf(ax * ax + ay * ay + az * az);
+  // 合成加速度から静止時の 1G を差し引いて使用し、負値は 0 とする
+  float totalG = sqrtf(ax * ax + ay * ay + az * az);
+  currentGForce = std::max(0.0F, totalG - 1.0F);
 
   // デモモード処理
   if (DEMO_MODE_ENABLED)

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -137,7 +137,16 @@ void acquireSensorData()
   M5.Imu.getAccelData(&ax, &ay, &az);
   // 縦方向 (Z) を除外して合成する
   float totalG = sqrtf(ax * ax + ay * ay);
-  currentGForce = totalG;
+
+  // 起動時の状態を 0G とみなすためのオフセット
+  static bool gForceOffsetInitialized = false;
+  static float gForceOffset = 0.0F;
+  if (!gForceOffsetInitialized)
+  {
+    gForceOffset = totalG;
+    gForceOffsetInitialized = true;
+  }
+  currentGForce = fabsf(totalG - gForceOffset);
 
   // デモモード処理
   if (DEMO_MODE_ENABLED)

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -132,12 +132,12 @@ void acquireSensorData()
 
   unsigned long now = millis();
 
-  // IMU から加速度を取得し合成値を計算
+  // IMU から加速度を取得し横方向のみの合成値を計算
   float ax = 0.0F, ay = 0.0F, az = 0.0F;
   M5.Imu.getAccelData(&ax, &ay, &az);
-  // 合成加速度から静止時の 1G を差し引いて使用し、負値は 0 とする
-  float totalG = sqrtf(ax * ax + ay * ay + az * az);
-  currentGForce = std::max(0.0F, totalG - 1.0F);
+  // 縦方向 (Z) を除外して合成する
+  float totalG = sqrtf(ax * ax + ay * ay);
+  currentGForce = totalG;
 
   // デモモード処理
   if (DEMO_MODE_ENABLED)

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -12,7 +12,7 @@ extern float oilPressureSamples[PRESSURE_SAMPLE_SIZE];
 extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
 extern bool oilPressureOverVoltage;
-extern float currentGForce;  // 現在の横方向合成加速度 [G]
+extern float currentGForce;  // 起動時からの横方向合成加速度変化 [G]
 
 void acquireSensorData();
 

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -12,7 +12,7 @@ extern float oilPressureSamples[PRESSURE_SAMPLE_SIZE];
 extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
 extern bool oilPressureOverVoltage;
-extern float currentGForce;  // 現在の合成加速度 [G]
+extern float currentGForce;  // 現在の横方向合成加速度 [G]
 
 void acquireSensorData();
 

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -12,6 +12,7 @@ extern float oilPressureSamples[PRESSURE_SAMPLE_SIZE];
 extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
 extern bool oilPressureOverVoltage;
+extern float currentGForce;  // 現在の合成加速度 [G]
 
 void acquireSensorData();
 

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -12,7 +12,8 @@ extern float oilPressureSamples[PRESSURE_SAMPLE_SIZE];
 extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
 extern bool oilPressureOverVoltage;
-extern float currentGForce;  // 起動時からの横方向合成加速度変化 [G]
+extern float currentGForce;     // 起動時からの水平加速度変化 [G]
+extern char currentGDirection;  // 現在の加速度の向き (R/L/F/R)
 
 void acquireSensorData();
 


### PR DESCRIPTION
## Summary
- show LOW warning when g-force exceeds 1G and oil pressure ≤ 3 bar
- enable IMU and calculate composite acceleration

## Testing
- `clang-format -i src/modules/sensor.h src/modules/sensor.cpp src/modules/display.cpp src/main.cpp`
- `clang-tidy src/modules/sensor.cpp src/modules/display.cpp src/main.cpp -p .` *(failed: Could not auto-detect compilation database)*
- `pio run -t compiledb` *(failed: HTTPClientError)*
- `./bin/act -j build` *(failed: no Docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_688f109b342483229411a22d5d5d72d4