### PR TITLE
Enable FPS display toggle / FPS表示のON/OFF機能を追加

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -10,6 +10,9 @@ constexpr bool DEBUG_MODE_ENABLED = false;
 // デモモードを有効にするかどうか
 constexpr bool DEMO_MODE_ENABLED = false;
 
+// FPS表示を行うかどうか
+constexpr bool FPS_DISPLAY_ENABLED = false;
+
 // ── センサー接続可否（false にするとその項目は常に 0 表示） ──
 constexpr bool SENSOR_OIL_PRESSURE_PRESENT = true;
 constexpr bool SENSOR_WATER_TEMP_PRESENT = true;

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -147,7 +147,12 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
     displayCache.waterTempAvg = waterTempAvg;
   }
 
-  bool fpsChanged = drawFpsOverlay();
+  bool fpsChanged = false;
+  if (FPS_DISPLAY_ENABLED)
+  {
+    // FPS表示が有効な場合のみ描画する
+    fpsChanged = drawFpsOverlay();
+  }
 
   // 値が更新されたときのみスプライトを転送する
   if (oilChanged || pressureChanged || waterChanged || fpsChanged)

--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -2,6 +2,7 @@
 
 #include <M5CoreS3.h>
 
+#include "config.h"
 #include "display.h"
 
 // FPSラベルが描画済みかどうかを保持
@@ -11,6 +12,12 @@ static unsigned long lastFpsDrawTime = 0;
 // ────────────────────── FPS表示 ──────────────────────
 auto drawFpsOverlay() -> bool
 {
+  if (!FPS_DISPLAY_ENABLED)
+  {
+    // FPS表示が無効な場合は何もしない
+    return false;
+  }
+
   mainCanvas.setFont(&fonts::Font0);
   mainCanvas.setTextSize(0);
   // FPS表示を目立たせないよう文字色をグレーに設定


### PR DESCRIPTION
## Summary
- Allow enabling or disabling FPS overlay via configuration
- Render FPS indicator only when the toggle is active

## Testing
- `clang-tidy include/config.h src/modules/display.cpp src/modules/fps_display.cpp -- -std=c++17 -Iinclude -Isrc` (failed: Error while processing files)
- `act -j build` (failed: Missing Docker connection and required image selection)

------
https://chatgpt.com/codex/tasks/task_e_6890c597426083229288fc66521a2b6f