### PR TITLE
fix: remove decimal from WATER.T MAX and align oil unit / WATER.T MAXの小数点削除と油圧単位の下揃え

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -27,6 +27,16 @@ static auto calculateMedian(const int *samples) -> int
   return sortedSamples[MEDIAN_BUFFER_SIZE / 2];
 }
 
+// 指定された輝度モードを適用
+void applyBrightnessMode(BrightnessMode mode)
+{
+  currentBrightnessMode = mode;
+  int targetBrightness = (mode == BrightnessMode::Day)    ? BACKLIGHT_DAY
+                         : (mode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
+                                                          : BACKLIGHT_NIGHT;
+  display.setBrightness(targetBrightness);
+}
+
 // ────────────────────── 輝度更新 ──────────────────────
 void updateBacklightLevel()
 {
@@ -34,8 +44,7 @@ void updateBacklightLevel()
   {
     if (currentBrightnessMode != BrightnessMode::Day)
     {
-      currentBrightnessMode = BrightnessMode::Day;
-      display.setBrightness(BACKLIGHT_DAY);
+      applyBrightnessMode(BrightnessMode::Day);
     }
     return;
   }
@@ -61,10 +70,6 @@ void updateBacklightLevel()
 
   if (newMode != currentBrightnessMode)
   {
-    currentBrightnessMode = newMode;
-    int targetBrightness = (newMode == BrightnessMode::Day)    ? BACKLIGHT_DAY
-                           : (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
-                                                               : BACKLIGHT_NIGHT;
-    display.setBrightness(targetBrightness);
+    applyBrightnessMode(newMode);
   }
 }

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -14,5 +14,7 @@ extern int medianLuxValue;
 constexpr int ALS_MEASUREMENT_INTERVAL_MS = 8000;
 
 void updateBacklightLevel();
+// 指定された輝度モードを適用
+void applyBrightnessMode(BrightnessMode mode);
 
 #endif  // BACKLIGHT_H

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -8,6 +8,8 @@
 #include "DrawFillArcMeter.h"
 #include "backlight.h"
 #include "fps_display.h"
+#include "low_warning.h"
+#include "sensor.h"
 
 // ────────────────────── グローバル変数 ──────────────────────
 M5GFX display;
@@ -147,10 +149,19 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
     displayCache.waterTempAvg = waterTempAvg;
   }
 
+  bool warnChanged = false;
+  bool isWarnShowing = drawLowPressureWarning(mainCanvas, currentGForce, pressureAvg, warnChanged);
+  if (warnChanged && !isWarnShowing)
+  {
+    // 警告が消えたら油圧ゲージを再描画して元に戻す
+    bool isUseDecimal = pressureAvg < 9.95F;
+    drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "x100kPa", "OIL.P",
+                     recordedMaxOilPressure, prevPressureValue, 0.5f, isUseDecimal, 0, 60, false);
+  }
   bool fpsChanged = drawFpsOverlay();
 
   // 値が更新されたときのみスプライトを転送する
-  if (oilChanged || pressureChanged || waterChanged || fpsChanged)
+  if (oilChanged || pressureChanged || waterChanged || fpsChanged || warnChanged)
   {
     mainCanvas.pushSprite(0, 0);
   }
@@ -240,34 +251,23 @@ void drawMenuScreen()
   mainCanvas.drawRect(0, 0, LCD_WIDTH, LCD_HEIGHT, BORDER_COLOR);
 
   // 画面高さに合わせて行間を自動計算し、下にはみ出さないようにする
-  constexpr int MENU_TOP_MARGIN = 20;                                                       // 上端の余白
-  constexpr int MENU_BOTTOM_MARGIN = 40;                                                    // 下端の余白（戻る案内分）
-  constexpr int MENU_LINES = SENSOR_AMBIENT_LIGHT_PRESENT ? 7 : 6;                          // 表示行数
+  constexpr int MENU_TOP_MARGIN = 20;     // 上端の余白
+  constexpr int MENU_BOTTOM_MARGIN = 40;  // 下端の余白（戻る案内分）
+  // 表示行数を減らして行間を確保
+  // OIL.P WARN の詳細表示を2行で確保するため1行分多く確保
+  constexpr int MENU_LINES = SENSOR_AMBIENT_LIGHT_PRESENT ? 7 : 5;                          // 表示行数
   const int lineHeight = (LCD_HEIGHT - MENU_TOP_MARGIN - MENU_BOTTOM_MARGIN) / MENU_LINES;  // 行間
 
   int y = MENU_TOP_MARGIN;
-  mainCanvas.setCursor(10, y);
-  // ラベルは左寄せ、値は右寄せで表示
-  mainCanvas.print("OIL.P MAX:");
-  if (SENSOR_OIL_PRESSURE_PRESENT)
-  {
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxOilPressure);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-  else
-  {
-    // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
-  }
 
-  y += lineHeight;
+  // 最高水温を表示
   mainCanvas.setCursor(10, y);
   mainCanvas.print("WATER.T MAX:");
   if (SENSOR_WATER_TEMP_PRESENT)
   {
     char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxWaterTemp);
+    // 小数点を表示しない
+    snprintf(valStr, sizeof(valStr), "%6.0f", recordedMaxWaterTemp);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
   }
   else
@@ -277,6 +277,7 @@ void drawMenuScreen()
   }
 
   y += lineHeight;
+  // 最高油温を表示
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T MAX:");
   if (SENSOR_OIL_TEMP_PRESENT)
@@ -292,11 +293,69 @@ void drawMenuScreen()
   }
 
   y += lineHeight;
+  // 最高油圧を表示
+  mainCanvas.setCursor(10, y);
+  mainCanvas.print("OIL.P MAX:");
+  if (SENSOR_OIL_PRESSURE_PRESENT)
+  {
+    char valStr[8];
+    snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxOilPressure);
+    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+  }
+  else
+  {
+    // センサー無効時は Disabled と表示
+    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
+  }
+
+  y += lineHeight;
+  // 直近の低油圧イベント情報を2行で表示
+  mainCanvas.setCursor(10, y);
+  mainCanvas.print("OIL.P WARN:");
+  y += lineHeight;
+  if (lastLowEventDuration > 0.0F)
+  {
+    // 方向, G値, 継続秒数, 油圧をカンマ区切りで作成（カンマ後にスペースを入れる）
+    char detailStr[40];
+    snprintf(detailStr, sizeof(detailStr), "%s, %.1fG, %.1fs, %.1f", lastLowEventDir, lastLowEventG, lastLowEventDuration,
+             lastLowEventPressure);
+
+    const int right = LCD_WIDTH - 10;  // 右端位置
+    // 詳細文字列の幅と高さを測定（通常フォント）
+    mainCanvas.setFont(&fonts::FreeSansBold12pt7b);
+    int textWidth = mainCanvas.textWidth(detailStr);
+    int textHeight = mainCanvas.fontHeight();
+
+    // 単位 "x100kPa" の幅と高さを小さいフォントで測定
+    mainCanvas.setFont(&fonts::Font0);
+    int unitWidth = mainCanvas.textWidth("x100kPa");
+    int unitHeight = mainCanvas.fontHeight();
+
+    int startX = right - unitWidth - textWidth;
+
+    // 詳細文字列を描画
+    mainCanvas.setFont(&fonts::FreeSansBold12pt7b);
+    mainCanvas.setCursor(startX, y);
+    mainCanvas.print(detailStr);
+
+    // 単位部分を小さいフォントで描画（数値の下端に揃える）
+    mainCanvas.setFont(&fonts::Font0);
+    mainCanvas.setCursor(startX + textWidth, y + textHeight - unitHeight);
+    mainCanvas.print("x100kPa");
+    // フォントを元に戻す
+    mainCanvas.setFont(&fonts::FreeSansBold12pt7b);
+  }
+  else
+  {
+    mainCanvas.drawRightString("None", LCD_WIDTH - 10, y);
+  }
+
+  y += lineHeight;
   mainCanvas.setCursor(10, y);
   if (SENSOR_AMBIENT_LIGHT_PRESENT)
   {
     // 現在のLUX値を表示
-    mainCanvas.print("LUX NOW:");
+    mainCanvas.print("LUX LATEST:");
     char valStr[8];
     snprintf(valStr, sizeof(valStr), "%6d", latestLux);
     mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
@@ -312,7 +371,7 @@ void drawMenuScreen()
   else
   {
     // LUX センサーが無い場合は両方 Disabled を表示
-    mainCanvas.print("LUX NOW:");
+    mainCanvas.print("LUX LATEST:");
     mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
 
     y += 25;

--- a/src/modules/low_warning.cpp
+++ b/src/modules/low_warning.cpp
@@ -1,0 +1,110 @@
+#include "low_warning.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "config.h"
+#include "sensor.h"
+
+// 直近の低油圧イベント情報
+float lastLowEventG = 0.0F;             // 発生時のG値
+const char *lastLowEventDir = "Right";  // Gの向き
+float lastLowEventDuration = 0.0F;      // 継続時間[s]
+float lastLowEventPressure = 0.0F;      // そのときの油圧[bar]
+
+// 油圧警告表示。現在の表示状態とその変更の有無を返す
+bool drawLowPressureWarning(M5Canvas &canvas, float gForce, float pressure, bool &stateChanged)
+{
+  // ゲージ位置とサイズ
+  constexpr int GAUGE_X = 0;    // 油圧ゲージの左上X
+  constexpr int GAUGE_Y = 60;   // 油圧ゲージの左上Y
+  constexpr int GAUGE_W = 160;  // ゲージ幅
+  constexpr int GAUGE_H = 170;  // ゲージ高さ
+
+  canvas.setFont(&fonts::FreeSansBold12pt7b);
+  // 警告文字列は固定で "LOW"
+  constexpr char WARN_TEXT[] = "LOW";
+  int textW = canvas.textWidth(WARN_TEXT);
+  int textH = canvas.fontHeight();
+  constexpr int PADDING = 4;  // ボックス余白
+  int boxW = textW + (PADDING * 2);
+  int boxH = textH + (PADDING * 2);
+  int boxX = GAUGE_X + ((GAUGE_W - boxW) / 2);
+  int boxY = GAUGE_Y + ((GAUGE_H - boxH) / 2);
+  static int lastBoxX = boxX;  // 最後に描画したボックス座標
+  static int lastBoxY = boxY;
+  static int lastBoxW = boxW;
+  static int lastBoxH = boxH;
+
+  // 横Gが1Gを超えた場合に判定
+  constexpr float G_FORCE_THRESHOLD = 1.0F;          // G判定値
+  constexpr float PRESSURE_THRESHOLD = 3.0F;         // 油圧閾値
+  constexpr unsigned long WARNING_DELAY_MS = 500UL;  // 継続時間
+  bool conditionMet = (gForce > G_FORCE_THRESHOLD && pressure <= PRESSURE_THRESHOLD);
+  static unsigned long startMs = 0;  // 条件成立開始時刻
+  static bool isShowing = false;
+  static float peakG = 0.0F;                                     // 期間中の最大G
+  static float minPressure = std::numeric_limits<float>::max();  // 期間中の最低油圧
+  static const char *eventDir = "Right";                         // 発生方向
+  unsigned long now = millis();
+  bool shouldShow = false;
+
+  if (conditionMet)
+  {
+    if (startMs == 0)
+    {
+      startMs = now;
+      peakG = gForce;
+      minPressure = pressure;
+      eventDir = currentGDirection;
+    }
+    else
+    {
+      peakG = std::max(peakG, gForce);
+      minPressure = std::min(minPressure, pressure);
+    }
+    if (now - startMs >= WARNING_DELAY_MS)
+    {
+      // 0.5秒以上継続したら警告表示
+      // サイズ変化に対応するため以前のボックスを消去
+      if (isShowing)
+      {
+        canvas.fillRect(lastBoxX, lastBoxY, lastBoxW, lastBoxH, COLOR_BLACK);
+      }
+      // 赤背景に固定文言を表示
+      canvas.fillRect(boxX, boxY, boxW, boxH, COLOR_RED);
+      canvas.setTextColor(COLOR_WHITE, COLOR_RED);
+      canvas.setCursor(boxX + ((boxW - textW) / 2), boxY + ((boxH - textH) / 2));
+      canvas.print(WARN_TEXT);
+      // 消去用にボックス位置とサイズを保持
+      lastBoxX = boxX;
+      lastBoxY = boxY;
+      lastBoxW = boxW;
+      lastBoxH = boxH;
+      shouldShow = true;
+    }
+  }
+  else
+  {
+    // 条件外になったらタイマーをリセットし、表示していれば消去
+    if (startMs != 0)
+    {
+      // 条件解除時にイベント情報を記録
+      lastLowEventG = peakG;
+      lastLowEventDir = eventDir;
+      lastLowEventDuration = (now - startMs) / 1000.0F;
+      lastLowEventPressure = minPressure;
+    }
+    startMs = 0;
+    if (isShowing)
+    {
+      // 直前に描画した領域を完全に消去
+      canvas.fillRect(lastBoxX, lastBoxY, lastBoxW, lastBoxH, COLOR_BLACK);
+    }
+  }
+
+  stateChanged = (shouldShow != isShowing);
+  isShowing = shouldShow;
+  return shouldShow;
+}

--- a/src/modules/low_warning.h
+++ b/src/modules/low_warning.h
@@ -1,0 +1,15 @@
+#ifndef LOW_WARNING_H
+#define LOW_WARNING_H
+
+#include <M5GFX.h>
+
+// 直近の低油圧イベント情報
+extern float lastLowEventG;          // 発生時のG値
+extern const char *lastLowEventDir;  // Gの向き
+extern float lastLowEventDuration;   // 継続時間[s]
+extern float lastLowEventPressure;   // そのときの油圧[bar]
+
+// 低油圧警告表示。現在の表示状態とその変更の有無を返す
+bool drawLowPressureWarning(M5Canvas &canvas, float gForce, float pressure, bool &stateChanged);
+
+#endif  // LOW_WARNING_H

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -1,5 +1,6 @@
 #include "sensor.h"
 
+#include <M5CoreS3.h>
 #include <Wire.h>
 
 #include <algorithm>
@@ -13,6 +14,8 @@ float oilPressureSamples[PRESSURE_SAMPLE_SIZE] = {};
 float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE] = {};
 float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE] = {};
 bool oilPressureOverVoltage = false;
+float currentGForce = 0.0F;
+const char *currentGDirection = "Right";
 static int oilPressureIndex = 0;
 static int waterTempIndex = 0;
 static int oilTempIndex = 0;
@@ -129,6 +132,102 @@ void acquireSensorData()
                                   1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 0.0F, 0.0F, 2.5F};
 
   unsigned long now = millis();
+
+  // IMU から加速度を取得
+  float ax = 0.0F, ay = 0.0F, az = 0.0F;
+  M5.Imu.getAccelData(&ax, &ay, &az);
+
+  // ── 起動直後は複数サンプルからオフセットを平均化し縦軸を判定 ──
+  static bool gForceOffsetInitialized = false;
+  static float axOffset = 0.0F;
+  static float ayOffset = 0.0F;
+  static float azOffset = 0.0F;
+  static int offsetSampleCount = 0;
+  static int verticalAxis = 2;  // 0:X, 1:Y, 2:Z
+  if (!gForceOffsetInitialized)
+  {
+    axOffset += ax;
+    ayOffset += ay;
+    azOffset += az;
+    offsetSampleCount++;
+    if (offsetSampleCount >= 20)
+    {
+      axOffset /= offsetSampleCount;
+      ayOffset /= offsetSampleCount;
+      azOffset /= offsetSampleCount;
+
+      // 最大オフセットを持つ軸を縦方向とみなす
+      float absOffsets[3] = {fabsf(axOffset), fabsf(ayOffset), fabsf(azOffset)};
+      verticalAxis = 0;
+      if (absOffsets[1] > absOffsets[verticalAxis]) verticalAxis = 1;
+      if (absOffsets[2] > absOffsets[verticalAxis]) verticalAxis = 2;
+
+      gForceOffsetInitialized = true;
+    }
+    else
+    {
+      // オフセット確定までは 0G 扱い
+      currentGForce = 0.0F;
+      currentGDirection = "Right";
+      return;
+    }
+  }
+
+  float adjX = ax - axOffset;
+  float adjY = ay - ayOffset;
+  float adjZ = az - azOffset;
+
+  // 縦軸を除いた 2 軸のみで判定
+  int lateralAxis = 0;       // 左右成分を持つ軸
+  int longitudinalAxis = 0;  // 前後成分を持つ軸
+  if (verticalAxis == 0)
+  {
+    lateralAxis = 1;       // Y: 左右
+    longitudinalAxis = 2;  // Z: 前後
+  }
+  else if (verticalAxis == 1)
+  {
+    lateralAxis = 0;       // X: 左右
+    longitudinalAxis = 2;  // Z: 前後
+  }
+  else  // verticalAxis == 2
+  {
+    lateralAxis = 1;       // Y: 左右
+    longitudinalAxis = 0;  // X: 前後
+  }
+
+  float lat = (lateralAxis == 0) ? adjX : (lateralAxis == 1) ? adjY : adjZ;
+  float lon = (longitudinalAxis == 0) ? adjX : (longitudinalAxis == 1) ? adjY : adjZ;
+  float absLat = fabsf(lat);
+  float absLon = fabsf(lon);
+
+  // 方向判定。真横判定の範囲を広げるため比率で判定する
+  constexpr float PURE_RATIO = 0.75F;  // 斜め判定のしきい値
+  if (absLat >= absLon * PURE_RATIO)
+  {
+    // 左右方向として扱う
+    currentGForce = sqrtf((lat * lat) + (lon * lon));
+    currentGDirection = (lat >= 0.0F) ? "Right" : "Left";
+  }
+  else if (absLon >= absLat * PURE_RATIO)
+  {
+    // 前後方向として扱う
+    currentGForce = sqrtf((lat * lat) + (lon * lon));
+    currentGDirection = (lon >= 0.0F) ? "Front" : "Rear";
+  }
+  else
+  {
+    // 斜め方向
+    currentGForce = sqrtf((lat * lat) + (lon * lon));
+    if (lat >= 0.0F)
+    {
+      currentGDirection = (lon >= 0.0F) ? "Right/Front" : "Right/Rear";
+    }
+    else
+    {
+      currentGDirection = (lon >= 0.0F) ? "Left/Front" : "Left/Rear";
+    }
+  }
 
   // デモモード処理
   if (DEMO_MODE_ENABLED)

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -12,6 +12,8 @@ extern float oilPressureSamples[PRESSURE_SAMPLE_SIZE];
 extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
 extern bool oilPressureOverVoltage;
+extern float currentGForce;            // 起動時からの水平加速度変化 [G]
+extern const char *currentGDirection;  // 現在の加速度の向き (Right/Left/Front/Rear など)
 
 void acquireSensorData();
 


### PR DESCRIPTION
## Summary
- display WATER.T MAX as integer without decimal / WATER.T MAX の値を整数表示に変更
- bottom-align "x100kPa" unit in low oil warning details / 低油圧警告の単位 "x100kPa" を下端揃えで表示

## Testing
- `clang-format -i src/modules/display.cpp`
- `clang-tidy src/modules/display.cpp -p .` *(failed: No compilation database found; 15546 warnings and 1 error)*
- `act -j build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f109b342483229411a22d5d5d72d4