### PR TITLE
サンプルバッファ更新インデックスの修正 / Fix sample buffer update index

### DIFF
--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -101,7 +101,8 @@ static void updateSampleBuffer(float value, float (&buffer)[N], int &index, bool
     {
       v = value;
     }
-    index = 1 % N;  // 初期化後は 1 番目から開始
+    // 初期化直後は最初の要素から更新を再開する
+    index = 0;
     first = false;
   }
   else

--- a/test/test_sensor_conversion.cpp
+++ b/test/test_sensor_conversion.cpp
@@ -48,6 +48,18 @@ void test_calculate_average()
   TEST_ASSERT_FLOAT_WITHIN(0.01f, 2.0f, avg);
 }
 
+// サンプルバッファ更新のテスト
+void test_update_sample_buffer()
+{
+  float buffer[3] = {};
+  int index = 0;
+  bool first = true;
+  updateSampleBuffer(1.0f, buffer, index, first);
+  updateSampleBuffer(2.0f, buffer, index, first);
+  // 初期化後は先頭要素から更新されるため buffer[0] は2になる
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 2.0f, buffer[0]);
+}
+
 // テスト実行
 void setup()
 {
@@ -56,6 +68,7 @@ void setup()
   RUN_TEST(test_convert_voltage_to_oil_pressure);
   RUN_TEST(test_convert_voltage_to_temp);
   RUN_TEST(test_calculate_average);
+  RUN_TEST(test_update_sample_buffer);
   UNITY_END();
 }
 


### PR DESCRIPTION
## Summary
- サンプルバッファ初期化後のインデックスを先頭に戻して、最初の要素が正しく更新されるように修正
- サンプルバッファ更新を確認する単体テストを追加

## Testing
- `./bin/act -j build` (Docker が無いため失敗)
- `platformio test -e m5stack-cores3-ci` (依存取得中に中断)
- `clang-format -i src/modules/sensor.cpp test/test_sensor_conversion.cpp`
- `clang-tidy src/modules/sensor.cpp -- -Iinclude` (多数の警告と1件のエラー)
- `clang-tidy test/test_sensor_conversion.cpp -- -Iinclude -Isrc/modules` (多数の警告と1件のエラー)


------
https://chatgpt.com/codex/tasks/task_e_68a970089c888322b0b2a2a3e12598d9