### PR TITLE
G方向判定をFR/RR/FL/RL表記に対応 / Support FR/RR/FL/RL notation for G-force direction detection

### DIFF
--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -202,31 +202,29 @@ void acquireSensorData()
   float absLat = fabsf(lat);
   float absLon = fabsf(lon);
 
-  // 方向判定。真横判定の範囲を広げるため比率で判定する
-  constexpr float PURE_RATIO = 0.75F;  // 斜め判定のしきい値
-  if (absLat >= absLon * PURE_RATIO)
-  {
-    // 左右方向として扱う
-    currentGForce = sqrtf((lat * lat) + (lon * lon));
-    currentGDirection = (lat >= 0.0F) ? "Right" : "Left";
-  }
-  else if (absLon >= absLat * PURE_RATIO)
+  // 方向判定。許容角度 10 度以内で単独方向とする
+  constexpr float PURE_TAN = 0.17632698F;  // tan(10度)
+  currentGForce = sqrtf((lat * lat) + (lon * lon));
+  if (absLat <= absLon * PURE_TAN)
   {
     // 前後方向として扱う
-    currentGForce = sqrtf((lat * lat) + (lon * lon));
     currentGDirection = (lon >= 0.0F) ? "Front" : "Rear";
+  }
+  else if (absLon <= absLat * PURE_TAN)
+  {
+    // 左右方向として扱う
+    currentGDirection = (lat >= 0.0F) ? "Right" : "Left";
   }
   else
   {
-    // 斜め方向
-    currentGForce = sqrtf((lat * lat) + (lon * lon));
-    if (lat >= 0.0F)
+    // 斜め方向 (Front/Rear + Left/Right)
+    if (lon >= 0.0F)
     {
-      currentGDirection = (lon >= 0.0F) ? "Right/Front" : "Right/Rear";
+      currentGDirection = (lat >= 0.0F) ? "FR" : "FL";
     }
     else
     {
-      currentGDirection = (lon >= 0.0F) ? "Left/Front" : "Left/Rear";
+      currentGDirection = (lat >= 0.0F) ? "RR" : "RL";
     }
   }
 

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -13,7 +13,7 @@ extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
 extern bool oilPressureOverVoltage;
 extern float currentGForce;            // 起動時からの水平加速度変化 [G]
-extern const char *currentGDirection;  // 現在の加速度の向き (Right/Left/Front/Rear など)
+extern const char *currentGDirection;  // 現在の加速度の向き (FR/RR/FL/RL, Front, Rear など)
 
 void acquireSensorData();
 


### PR DESCRIPTION
## Summary (概要)
- G方向の判定に10度の許容角を導入し、FR/RR/FL/RLの表記に対応
- 斜め方向の表記を簡潔化し、純粋な前後はFront/Rearを返すよう変更

## Testing (テスト)
- `clang-format -i src/modules/sensor.cpp src/modules/sensor.h`
- `clang-tidy src/modules/sensor.cpp src/modules/sensor.h -- -Iinclude` (多数の警告とエラーにより失敗)
- `act -j build` (コマンド未インストールのため実行不可)
- `apt-get install -y act` (パッケージ未検出のため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68ad362d88048322899540e9e51f804d