### PR TITLE
calculateAverageのゼロ除算を防止 / Prevent division by zero in calculateAverage

### DIFF
--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -21,6 +21,12 @@ void acquireSensorData();
 template <size_t N>
 inline auto calculateAverage(const float (&values)[N]) -> float
 {
+  // 配列サイズが0の場合は0を返す
+  if (N == 0)
+  {
+    return 0.0F;
+  }
+
   float sum = 0.0F;
   for (size_t i = 0; i < N; ++i)
   {


### PR DESCRIPTION
## Summary
- 平均計算時に配列サイズ0を考慮
- Handle zero-sized arrays in average calculation

## Testing
- `clang-format -i src/modules/sensor.h`
- `clang-tidy src/modules/sensor.h -- -Iinclude -Isrc -std=c++17` (ヘッダー不足で失敗)
- `pio test -e m5stack-cores3-ci` (HTTPClientErrorで失敗)
- `act -j build` (コマンドが見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_68b184d6f2d08322820fbd3662cace13