### PR TITLE
fix: guard brightness on VBUS voltage / VBUS電圧に基づく輝度ガードの修正

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -78,6 +78,14 @@ constexpr uint8_t BACKLIGHT_DAY = 255;
 constexpr uint8_t BACKLIGHT_DUSK = 200;
 constexpr uint8_t BACKLIGHT_NIGHT = 60;
 
+// ── 輝度ガード設定 ──
+#define RG_ENABLE_VOLTAGE_GUARD 1       // 電圧ガード機能の有効化
+#define RG_VIN_SAMPLE_WINDOW_MS 500     // 電圧移動平均窓 [ms]
+#define RG_VIN_MIN_FOR_RISE_V 4.80f     // 輝度上昇を許可する最低電圧
+#define RG_VIN_HYSTERESIS_V 0.10f       // ヒステリシス幅 [V]
+#define RG_BRIGHTNESS_CAP_UNDER_VIN 80  // 電圧不足時の輝度上限
+#define RG_RETRY_AFTER_MS 1000          // 再評価までの待ち時間 [ms]
+
 constexpr int MEDIAN_BUFFER_SIZE = 6;
 
 // FPS 更新間隔 [ms]

--- a/src/display/brightness_guard.cpp
+++ b/src/display/brightness_guard.cpp
@@ -1,0 +1,58 @@
+#include "display/brightness_guard.h"
+
+#include "config.h"
+#include "modules/display.h"
+
+namespace
+{
+IVoltageProvider* g_provider = nullptr;  // 電圧取得プロバイダ
+uint8_t g_currentBrightness = 0;         // 現在適用中の輝度
+unsigned long g_nextRetryMs = 0;         // 再評価可能時刻
+}  // namespace
+
+namespace GuardedBrightness
+{
+void setVoltageProvider(IVoltageProvider* provider) { g_provider = provider; }
+
+void apply(uint8_t requested)
+{
+#if RG_ENABLE_VOLTAGE_GUARD
+  if (g_provider == nullptr)
+  {
+    static VoltageProvider defaultProvider;
+    g_provider = &defaultProvider;  // デフォルト実装
+  }
+
+  unsigned long now = millis();
+  if (requested > g_currentBrightness && now < g_nextRetryMs)
+  {
+    return;  // 再評価待ち時間中は変更しない
+  }
+
+  float vin = g_provider->readVin();
+  uint8_t decided =
+      decide(g_currentBrightness, requested, vin, RG_VIN_MIN_FOR_RISE_V, RG_VIN_HYSTERESIS_V, RG_BRIGHTNESS_CAP_UNDER_VIN);
+  if (requested > g_currentBrightness && decided < requested)
+  {
+    g_nextRetryMs = now + RG_RETRY_AFTER_MS;  // 抑制した場合は次回再評価時刻を設定
+  }
+  else
+  {
+    g_nextRetryMs = now;
+  }
+
+  if (decided != g_currentBrightness)
+  {
+    display.setBrightness(decided);
+    g_currentBrightness = decided;
+  }
+
+#ifdef RG_DEBUG_POWER
+  Serial.printf("[PowerGuard] vin=%.2fV, request=%u -> apply=%u\n", vin, requested, decided);
+#endif
+#else
+  display.setBrightness(requested);
+  g_currentBrightness = requested;
+#endif
+}
+}  // namespace GuardedBrightness

--- a/src/display/brightness_guard.h
+++ b/src/display/brightness_guard.h
@@ -1,0 +1,36 @@
+#ifndef BRIGHTNESS_GUARD_H
+#define BRIGHTNESS_GUARD_H
+
+#include <algorithm>
+#include <cstdint>
+
+#include "power/voltage_provider.h"
+
+namespace GuardedBrightness
+{
+// 電圧と現在値に基づいて最終輝度を決定する
+inline uint8_t decide(uint8_t current, uint8_t requested, float vin, float min_for_rise, float hysteresis, uint8_t cap)
+{
+  if (requested <= current)
+  {
+    // 下げ方向は常に許可
+    return requested;
+  }
+  float rise_on = min_for_rise + hysteresis;
+  float rise_off = min_for_rise - hysteresis;
+  if (vin >= rise_on)
+  {
+    return requested;  // 十分な電圧があるため上昇許可
+  }
+  if (vin < rise_off)
+  {
+    return std::min<uint8_t>(requested, cap);  // 電圧不足時は上限に丸める
+  }
+  return current;  // ヒステリシス帯域では現状維持
+}
+
+void apply(uint8_t requested);
+void setVoltageProvider(IVoltageProvider* provider);
+}  // namespace GuardedBrightness
+
+#endif  // BRIGHTNESS_GUARD_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <Wire.h>
 
 #include "config.h"
+#include "display/brightness_guard.h"
 #include "modules/backlight.h"
 #include "modules/display.h"
 #include "modules/sensor.h"
@@ -50,7 +51,7 @@ void setup()
   display.initDMA();
   display.setRotation(3);
   display.setColorDepth(DISPLAY_COLOR_DEPTH);
-  display.setBrightness(BACKLIGHT_DAY);
+  GuardedBrightness::apply(BACKLIGHT_DAY);
 
   mainCanvas.setColorDepth(DISPLAY_COLOR_DEPTH);
   mainCanvas.setTextSize(1);

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include "display.h"
+#include "display/brightness_guard.h"
 
 // ────────────────────── グローバル変数 ──────────────────────
 // 現在の輝度モード
@@ -34,7 +35,7 @@ void applyBrightnessMode(BrightnessMode mode)
   int targetBrightness = (mode == BrightnessMode::Day)    ? BACKLIGHT_DAY
                          : (mode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
                                                           : BACKLIGHT_NIGHT;
-  display.setBrightness(targetBrightness);
+  GuardedBrightness::apply(targetBrightness);
 }
 
 // ────────────────────── 輝度更新 ──────────────────────

--- a/src/power/voltage_provider.cpp
+++ b/src/power/voltage_provider.cpp
@@ -1,0 +1,36 @@
+#include "power/voltage_provider.h"
+
+#include <algorithm>
+
+#include "config.h"
+
+// 最後に取得した正常値
+static float s_lastValid = RG_VIN_MIN_FOR_RISE_V;
+// 移動平均された電圧
+static float s_filtered = RG_VIN_MIN_FOR_RISE_V;
+// 前回更新時刻
+static unsigned long s_lastMs = 0;
+
+float VoltageProvider::readVin()
+{
+  float raw = M5.Power.getVBUSVoltage();  // USB給電電圧を取得
+  if (raw > 0.0f)
+  {
+    s_lastValid = raw;
+  }
+  else
+  {
+    raw = s_lastValid;  // 異常値の場合は最後の正常値を利用
+  }
+
+  unsigned long now = millis();
+  float alpha = 1.0f;
+  if (s_lastMs != 0)
+  {
+    float dt = static_cast<float>(now - s_lastMs);
+    alpha = std::min(dt / RG_VIN_SAMPLE_WINDOW_MS, 1.0f);  // 移動平均係数
+  }
+  s_filtered += (raw - s_filtered) * alpha;
+  s_lastMs = now;
+  return s_filtered;
+}

--- a/src/power/voltage_provider.h
+++ b/src/power/voltage_provider.h
@@ -1,0 +1,21 @@
+#ifndef VOLTAGE_PROVIDER_H
+#define VOLTAGE_PROVIDER_H
+
+#include <M5Unified.h>
+
+// 電圧取得インターフェイス
+class IVoltageProvider
+{
+ public:
+  virtual ~IVoltageProvider() = default;
+  virtual float readVin() = 0;  // 入力電圧を返す
+};
+
+// 実機の電圧取得クラス
+class VoltageProvider : public IVoltageProvider
+{
+ public:
+  float readVin() override;  // 移動平均済み電圧を返す
+};
+
+#endif  // VOLTAGE_PROVIDER_H

--- a/test/test_brightness_guard.cpp
+++ b/test/test_brightness_guard.cpp
@@ -1,0 +1,46 @@
+#include <unity.h>
+
+#include "../src/display/brightness_guard.h"
+
+// vin が低い場合はキャップまで丸める
+void test_decide_cap_under_voltage()
+{
+  uint8_t result = GuardedBrightness::decide(50, 120, 4.6f, 4.8f, 0.1f, 80);
+  TEST_ASSERT_EQUAL_UINT8(80, result);
+}
+
+// 十分な電圧なら要求輝度を適用
+void test_decide_allow_when_voltage_high()
+{
+  uint8_t result = GuardedBrightness::decide(50, 120, 5.0f, 4.8f, 0.1f, 80);
+  TEST_ASSERT_EQUAL_UINT8(120, result);
+}
+
+// 下げ要求は常に許可
+void test_decide_always_allow_decrease()
+{
+  uint8_t result = GuardedBrightness::decide(120, 80, 4.6f, 4.8f, 0.1f, 80);
+  TEST_ASSERT_EQUAL_UINT8(80, result);
+}
+
+// ヒステリシス帯域では現状維持
+void test_decide_hysteresis()
+{
+  uint8_t result = GuardedBrightness::decide(80, 120, 4.75f, 4.8f, 0.1f, 80);
+  TEST_ASSERT_EQUAL_UINT8(80, result);
+}
+
+void setup()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_decide_cap_under_voltage);
+  RUN_TEST(test_decide_allow_when_voltage_high);
+  RUN_TEST(test_decide_always_allow_decrease);
+  RUN_TEST(test_decide_hysteresis);
+  UNITY_END();
+}
+
+void loop()
+{
+  // ループ処理は不要
+}


### PR DESCRIPTION
## Summary
- use VBUS voltage for brightness guard moving average
- centralize brightness change via GuardedBrightness

## Testing
- `clang-format -i include/config.h src/power/voltage_provider.h src/power/voltage_provider.cpp src/display/brightness_guard.h src/display/brightness_guard.cpp src/main.cpp src/modules/backlight.cpp test/test_brightness_guard.cpp`
- `clang-tidy include/config.h src/power/voltage_provider.cpp src/display/brightness_guard.cpp src/main.cpp src/modules/backlight.cpp test/test_brightness_guard.cpp -- -std=c++17 -I./src -I./include` *(fails: missing headers and many warnings)*
- `act -j build` *(command not found)*
- `pio test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bfd1053c8322bd565bb037294e96