### PR TITLE
ヘッダ参照テストとM5Unifiedバージョン固定 / Reference header in tests and pin M5Unified version

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -25,6 +25,14 @@ constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
 // 0.3sq ケーブル往復14mで約0.137Vの降下を想定
 constexpr float VOLTAGE_DROP = 0.137f;
 
+// ── VBUS 監視設定 ──
+// 電圧が低下した際に負荷を制御するための閾値
+constexpr float VBUS_LOW_THRESHOLD = 4.75f;
+// 復帰判定用の閾値
+constexpr float VBUS_RECOVER_THRESHOLD = 4.80f;
+// VBUS を監視する間隔 [ms]
+constexpr unsigned long VBUS_CHECK_INTERVAL_MS = 100UL;
+
 // ── 色設定 (16 bit) ──
 // RGB888 から 565 形式へ変換する constexpr 関数
 constexpr uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b)

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ platform = espressif32
 board = m5stack-cores3
 framework = arduino
 lib_deps =
-  m5stack/M5Unified@^0.2.7
+  m5stack/M5Unified@^0.1.16
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep
@@ -31,7 +31,7 @@ platform = espressif32
 board = m5stack-cores3
 framework = arduino
 lib_deps =
-  m5stack/M5Unified@^0.2.7
+  m5stack/M5Unified@^0.1.16
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep

--- a/src/modules/power.cpp
+++ b/src/modules/power.cpp
@@ -1,0 +1,50 @@
+#include "power.h"
+
+// VBUS電圧を解析し、状態を更新する処理
+PowerAction processVbus(float vbus, unsigned long now, BrightnessMode currentMode, VbusState &state)
+{
+  PowerAction action = PowerAction::None;
+
+  // 一定間隔ごとにVBUS電圧を確認
+  if (now - state.lastVbusCheckMs >= VBUS_CHECK_INTERVAL_MS)
+  {
+    if (!state.isVoltageLow && vbus < VBUS_LOW_THRESHOLD)
+    {
+      // 閾値を下回ったら輝度を最小にする
+      state.isVoltageLow = true;
+      state.prevBrightness = currentMode;
+      state.recoverBrightness = BACKLIGHT_NIGHT;
+      action = PowerAction::ReduceBrightness;
+    }
+    else if (state.isVoltageLow && vbus >= VBUS_RECOVER_THRESHOLD)
+    {
+      // 電圧が回復したら復帰処理を開始
+      state.isVoltageLow = false;
+      state.isRecovering = true;
+      state.lastBrightnessStepMs = now;
+    }
+    state.lastVbusCheckMs = now;
+  }
+
+  if (state.isRecovering)
+  {
+    // 目標輝度を判断
+    uint8_t target = (state.prevBrightness == BrightnessMode::Day)    ? BACKLIGHT_DAY
+                     : (state.prevBrightness == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
+                                                                      : BACKLIGHT_NIGHT;
+    // 100ms ごとに10ずつ増加させる
+    if (state.recoverBrightness < target && now - state.lastBrightnessStepMs >= 100)
+    {
+      state.recoverBrightness = std::min<uint8_t>(state.recoverBrightness + 10, target);
+      state.lastBrightnessStepMs = now;
+      action = PowerAction::StepBrightness;
+    }
+    if (state.recoverBrightness >= target)
+    {
+      state.isRecovering = false;
+      action = PowerAction::RestoreBrightness;
+    }
+  }
+
+  return action;
+}

--- a/src/modules/power.h
+++ b/src/modules/power.h
@@ -1,0 +1,31 @@
+#ifndef POWER_H
+#define POWER_H
+
+#include <algorithm>
+
+#include "config.h"
+
+// VBUS監視や復帰制御の状態を保持する構造体
+struct VbusState
+{
+  bool isVoltageLow = false;                            // 電圧低下状態か
+  bool isRecovering = false;                            // 復帰中か
+  BrightnessMode prevBrightness = BrightnessMode::Day;  // 電圧低下前の輝度モード
+  unsigned long lastVbusCheckMs = 0;                    // VBUS監視を行った時刻
+  unsigned long lastBrightnessStepMs = 0;               // 輝度復帰ステップ時刻
+  uint8_t recoverBrightness = BACKLIGHT_NIGHT;          // 復帰中の現在輝度
+};
+
+// 電圧状態に応じてメイン側で行うべき処理
+enum class PowerAction
+{
+  None,              // 何もしない
+  ReduceBrightness,  // 輝度を夜間モードに落とす
+  StepBrightness,    // 段階的に輝度を上げる
+  RestoreBrightness  // 元の輝度モードへ戻す
+};
+
+// VBUS電圧と現在時刻、現在の輝度モードから状態を更新し、必要な処理を返す
+PowerAction processVbus(float vbus, unsigned long now, BrightnessMode currentMode, VbusState &state);
+
+#endif  // POWER_H

--- a/test/test_power.cpp
+++ b/test/test_power.cpp
@@ -1,0 +1,53 @@
+#include <unity.h>
+
+// VBUS制御ロジックをヘッダ経由でテスト
+#include "../src/modules/power.h"
+
+void test_vbus_reduce_and_recover()
+{
+  VbusState st;
+  unsigned long now = 0;
+  BrightnessMode mode = BrightnessMode::Day;
+
+  // 1. 電圧が閾値未満になった場合は夜間モードへ
+  PowerAction act = processVbus(VBUS_LOW_THRESHOLD - 0.1f, now, mode, st);
+  TEST_ASSERT_EQUAL(PowerAction::ReduceBrightness, act);
+  TEST_ASSERT_TRUE(st.isVoltageLow);
+  TEST_ASSERT_EQUAL(mode, st.prevBrightness);
+
+  // 2. 電圧が回復すると復帰モードへ移行
+  now += VBUS_CHECK_INTERVAL_MS;
+  act = processVbus(VBUS_RECOVER_THRESHOLD + 0.1f, now, mode, st);
+  TEST_ASSERT_FALSE(st.isVoltageLow);
+  TEST_ASSERT_TRUE(st.isRecovering);
+  TEST_ASSERT_EQUAL(PowerAction::None, act);
+
+  // 3. 復帰中は輝度が段階的に上昇
+  now += 100;
+  act = processVbus(VBUS_RECOVER_THRESHOLD + 0.1f, now, mode, st);
+  TEST_ASSERT_EQUAL(PowerAction::StepBrightness, act);
+  uint8_t first = st.recoverBrightness;
+  TEST_ASSERT_TRUE(first > BACKLIGHT_NIGHT);
+
+  // 4. 目標輝度まで進むと元のモードに戻る
+  PowerAction lastAct = PowerAction::None;
+  for (int i = 0; i < 50 && st.isRecovering; ++i)
+  {
+    now += 100;
+    lastAct = processVbus(VBUS_RECOVER_THRESHOLD + 0.1f, now, mode, st);
+  }
+  TEST_ASSERT_EQUAL(PowerAction::RestoreBrightness, lastAct);
+  TEST_ASSERT_FALSE(st.isRecovering);
+}
+
+void setup()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_vbus_reduce_and_recover);
+  UNITY_END();
+}
+
+void loop()
+{
+  // ループは未使用
+}


### PR DESCRIPTION
## Summary
- テストコードをモジュール実装ではなくヘッダ経由で参照するよう修正
- M5Unifiedライブラリを`^0.1.16`に固定

## Testing
- `clang-format -i test/test_power.cpp`
- `clang-tidy test/test_power.cpp -- -Iinclude -Isrc` *(missing `unity.h`, magic numbers)*
- `act -j build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c0eddeec83229b3ec6e3d31437bd