### PR TITLE
輝度変更前に電圧チェックを追加しM5ライブラリバージョンを表示 / Add voltage check before adjusting brightness and show M5 library version

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -24,6 +24,8 @@ constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
 // ── 電圧降下補正 ──
 // 0.3sq ケーブル往復14mで約0.137Vの降下を想定
 constexpr float VOLTAGE_DROP = 0.137f;
+// バッテリー電圧がこの値未満の場合は輝度を変更しない [mV]
+constexpr int16_t MIN_BATTERY_VOLTAGE_MV = 3300;
 
 // ── 色設定 (16 bit) ──
 // RGB888 から 565 形式へ変換する constexpr 関数

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <M5CoreS3.h>
-#include <WiFi.h>  // WiFi 無効化用
+#include <M5Unified.h>  // バージョン取得用
+#include <WiFi.h>       // WiFi 無効化用
 #include <Wire.h>
 
 #include "config.h"
@@ -32,6 +33,10 @@ static void printSensorDebugInfo()
 void setup()
 {
   Serial.begin(115200);
+
+  // M5ライブラリのバージョンをシリアルに表示
+  Serial.print("M5Unified version: ");
+  Serial.println(M5UNIFIED_VERSION);
 
   M5.begin();
   CoreS3.begin(M5.config());

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -30,6 +30,16 @@ static auto calculateMedian(const int *samples) -> int
 // 指定された輝度モードを適用
 void applyBrightnessMode(BrightnessMode mode)
 {
+  // 電圧を取得し、閾値未満なら輝度を変更しない
+  int16_t voltage = M5.Power.getBatteryVoltage();
+  if (voltage < MIN_BATTERY_VOLTAGE_MV)
+  {
+    if (DEBUG_MODE_ENABLED)
+    {
+      Serial.printf("[Power] voltage:%dmV, skip brightness change\n", voltage);
+    }
+    return;
+  }
   currentBrightnessMode = mode;
   int targetBrightness = (mode == BrightnessMode::Day)    ? BACKLIGHT_DAY
                          : (mode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK


### PR DESCRIPTION
## Summary
- バッテリー電圧を確認してからバックライト輝度を変更するよう改修
- 起動時にM5Unifiedライブラリのバージョンをシリアルへ出力

## Testing
- `clang-format -i include/config.h src/modules/backlight.cpp src/main.cpp`
- `clang-tidy include/config.h src/modules/backlight.cpp src/main.cpp -- -Iinclude` *(missing headers and many warnings)*
- `act -j build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b7b0359883229cd8138cc5a568ae