### PR TITLE
VBUS電圧低下時に輝度変更を延期 / Delay brightness change when VBUS voltage is low

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -78,6 +78,9 @@ constexpr uint8_t BACKLIGHT_DAY = 255;
 constexpr uint8_t BACKLIGHT_DUSK = 200;
 constexpr uint8_t BACKLIGHT_NIGHT = 60;
 
+// VBUS電圧がこの値を下回る場合は輝度変更を遅延する
+constexpr float VBUS_VOLTAGE_THRESHOLD = 4.6f;
+
 constexpr int MEDIAN_BUFFER_SIZE = 6;
 
 // FPS 更新間隔 [ms]

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ platform = espressif32
 board = m5stack-cores3
 framework = arduino
 lib_deps =
-  m5stack/M5Unified@^0.2.7
+  m5stack/M5Unified@^1.1.3
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep
@@ -31,7 +31,7 @@ platform = espressif32
 board = m5stack-cores3
 framework = arduino
 lib_deps =
-  m5stack/M5Unified@^0.2.7
+  m5stack/M5Unified@^1.1.3
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep

--- a/test/test_backlight.cpp
+++ b/test/test_backlight.cpp
@@ -1,0 +1,62 @@
+#include <unity.h>
+
+#define UNIT_TEST
+#define DISPLAY_H
+#include "../include/config.h"
+
+// ダミー表示デバイス
+struct MockDisplay
+{
+  int lastBrightness = -1;
+  void setBrightness(int b) { lastBrightness = b; }
+};
+MockDisplay display;
+
+// ダミーALSセンサー
+struct
+{
+  struct
+  {
+    int getAlsValue() { return 0; }
+  } Ltr553;
+} CoreS3;
+
+// ダミーシリアル出力
+struct
+{
+  void printf(const char*, ...) {}
+} Serial;
+
+// テスト用VBUS電圧
+static float testVbusVoltage = 5.0f;
+static float getVBusVoltage() { return testVbusVoltage; }
+
+#include "../src/modules/backlight.cpp"
+
+void test_skip_when_vbus_low()
+{
+  currentBrightnessMode = BrightnessMode::Day;
+  testVbusVoltage = VBUS_VOLTAGE_THRESHOLD - 0.1f;
+  applyBrightnessMode(BrightnessMode::Night);
+  TEST_ASSERT_EQUAL(BrightnessMode::Day, currentBrightnessMode);
+  TEST_ASSERT_EQUAL(-1, display.lastBrightness);
+}
+
+void test_apply_when_vbus_ok()
+{
+  currentBrightnessMode = BrightnessMode::Day;
+  testVbusVoltage = VBUS_VOLTAGE_THRESHOLD + 0.5f;
+  applyBrightnessMode(BrightnessMode::Night);
+  TEST_ASSERT_EQUAL(BrightnessMode::Night, currentBrightnessMode);
+  TEST_ASSERT_EQUAL(BACKLIGHT_NIGHT, display.lastBrightness);
+}
+
+void setup()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_skip_when_vbus_low);
+  RUN_TEST(test_apply_when_vbus_ok);
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary
- update M5Unified to latest release
- skip brightness changes while VBUS voltage is below threshold
- add unit tests for VBUS-based brightness control

## Testing
- `clang-format -i include/config.h src/modules/backlight.cpp test/test_backlight.cpp`
- `clang-tidy include/config.h src/modules/backlight.cpp test/test_backlight.cpp -- -std=c++17` (failed: missing headers and warnings)
- `act -j build` (failed: command not found)
- `pio test -e m5stack-cores3-ci` (incomplete: platform installation stalled)


------
https://chatgpt.com/codex/tasks/task_e_68b8416a764c83229022a1c0d28d0a40