### PR TITLE
READMEの配線図の表示崩れを修正 / Fix wiring diagram rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,10 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 ```mermaid
 graph TD
     subgraph "M5Stack CoreS3"
-        V5{
-{5V}}
-        GND{
-  {
-    GND
-  }}
+        V5{{5V}}
+        GND{{GND}}
     end
     ADS[ADS1015]
-
 
     V5 --> ADS
     GND --> ADS


### PR DESCRIPTION
## Summary
- READMEの配線図のMermaid記法を修正して正しく表示されるようにしました
- Corrected Mermaid syntax in README's wiring diagram for proper rendering

## Testing
- `clang-format -i src/main.cpp src/DrawFillArcMeter.h`
- `clang-tidy src/main.cpp -- -Iinclude` *(failed: 'M5CoreS3.h' file not found)*
- `act -j build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b846a46978832295f198abe74f20af