### PR TITLE
レーシングモードの継続時間を定数化 / Constantize racing mode duration

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -80,6 +80,9 @@ constexpr uint8_t BACKLIGHT_NIGHT = 60;
 
 constexpr int MEDIAN_BUFFER_SIZE = 6;
 
+// レーシングモード継続時間 [ms]
+constexpr unsigned long RACING_MODE_DURATION_MS = 180000UL;
+
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ void loop()
     racingPrevMode = currentBrightnessMode;
     applyBrightnessMode(BrightnessMode::Day);
   }
-  else if (isRacingMode && now - racingStartMs >= 180000UL)
+  else if (isRacingMode && now - racingStartMs >= RACING_MODE_DURATION_MS)
   {
     // 3分経過でレーシングモードを終了
     isRacingMode = false;


### PR DESCRIPTION
## Summary
- レーシングモード継続時間をconfigに定義
- ハードコードされた値を定数へ置換

## Testing
- `clang-format -i include/config.h src/main.cpp`
- `clang-tidy include/config.h src/main.cpp -p .` *(コンパイルデータベース不足で失敗)*
- `./bin/act -j build` *(Docker未設定で失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68b9333421bc8322b4a1d265edc60bc3