### PR TITLE
メニュー表示の再宣言エラー修正 / Fix redeclaration error in menu display

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,25 +1,25 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include <M5CoreS3.h>
+#include <cstdint>  // 整数型定義
 
 // ────────────────────── 設定 ──────────────────────
 // デバッグ用メッセージ表示の有無
-constexpr bool DEBUG_MODE_ENABLED = false;
+#define DEBUG_MODE_ENABLED 0
 
 // デモモードを有効にするかどうか
-constexpr bool DEMO_MODE_ENABLED = false;
+#define DEMO_MODE_ENABLED 0
 
 // FPS表示を行うかどうか
-constexpr bool FPS_DISPLAY_ENABLED = false;
+#define FPS_DISPLAY_ENABLED 0
 
-// ── センサー接続可否（false にするとその項目は常に 0 表示） ──
-constexpr bool SENSOR_OIL_PRESSURE_PRESENT = true;
-constexpr bool SENSOR_WATER_TEMP_PRESENT = true;
+// ── センサー接続可否（0 にするとその項目は常に 0 表示） ──
+#define SENSOR_OIL_PRESSURE_PRESENT 1
+#define SENSOR_WATER_TEMP_PRESENT 1
 // 油温センサーを使用するかどうか
-constexpr bool SENSOR_OIL_TEMP_PRESENT = true;
-// 照度センサーを使用する場合は true
-constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
+#define SENSOR_OIL_TEMP_PRESENT 1
+// 照度センサーを使用する場合は 1
+#define SENSOR_AMBIENT_LIGHT_PRESENT 1
 
 // ── 電圧降下補正 ──
 // 0.3sq ケーブル往復14mで約0.137Vの降下を想定

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,36 +74,34 @@ void setup()
   pinMode(8, INPUT_PULLUP);
   Wire.begin(9, 8);
 
-  if (!DEMO_MODE_ENABLED)
+#if !DEMO_MODE_ENABLED
+  // デモモードでなければADS1015を初期化し、失敗時は画面にエラーを表示
+  if (!adsConverter.begin())
   {
-    // デモモードでなければADS1015を初期化し、失敗時は画面にエラーを表示
-    if (!adsConverter.begin())
-    {
-      Serial.println("[ADS1015] init failed… all analog values will be 0");
-      M5.Lcd.setTextSize(2);
-      M5.Lcd.setTextColor(COLOR_RED);
-      M5.Lcd.setCursor(0, 0);
-      M5.Lcd.println("ADS1015 init failed");
-      M5.Lcd.println("Check wiring");
-    }
-    else
-    {
-      adsConverter.setDataRate(RATE_ADS1015_1600SPS);
-    }
+    Serial.println("[ADS1015] init failed… all analog values will be 0");
+    M5.Lcd.setTextSize(2);
+    M5.Lcd.setTextColor(COLOR_RED);
+    M5.Lcd.setCursor(0, 0);
+    M5.Lcd.println("ADS1015 init failed");
+    M5.Lcd.println("Check wiring");
   }
+  else
+  {
+    adsConverter.setDataRate(RATE_ADS1015_1600SPS);
+  }
+#endif
 
-  if (SENSOR_AMBIENT_LIGHT_PRESENT)
-  {
-    // ALS のゲインと積分時間を設定してから初期化
-    Ltr5xx_Init_Basic_Para ltr553Params = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
-    ltr553Params.ps_led_pulse_freq = LTR5XX_LED_PULSE_FREQ_40KHZ;
-    ltr553Params.als_gain = LTR5XX_ALS_GAIN_1X;
-    ltr553Params.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_100MS;
-    CoreS3.Ltr553.begin(&ltr553Params);
-    CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
-    // 初回起動時に照度を取得して輝度を決定
-    updateBacklightLevel();
-  }
+#if SENSOR_AMBIENT_LIGHT_PRESENT
+  // ALS のゲインと積分時間を設定してから初期化
+  Ltr5xx_Init_Basic_Para ltr553Params = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
+  ltr553Params.ps_led_pulse_freq = LTR5XX_LED_PULSE_FREQ_40KHZ;
+  ltr553Params.als_gain = LTR5XX_ALS_GAIN_1X;
+  ltr553Params.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_100MS;
+  CoreS3.Ltr553.begin(&ltr553Params);
+  CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
+  // 初回起動時に照度を取得して輝度を決定
+  updateBacklightLevel();
+#endif
 }
 
 // ────────────────────── loop() ──────────────────────
@@ -189,18 +187,19 @@ void loop()
   if (now - lastFpsSecond >= FPS_INTERVAL_MS)
   {
     currentFps = fpsFrameCounter;
-    if (DEBUG_MODE_ENABLED)
-    {
-      Serial.printf("FPS:%d\n", currentFps);
-    }
+#if DEBUG_MODE_ENABLED
+    Serial.printf("FPS:%d\n", currentFps);
+#endif
     fpsFrameCounter = 0;
     lastFpsSecond = now;
   }
 
-  if (DEBUG_MODE_ENABLED && now - lastDebugPrint >= 1000UL)
+#if DEBUG_MODE_ENABLED
+  if (now - lastDebugPrint >= 1000UL)
   {
     // FPS更新とは別に1秒ごとにデータを出力
     printSensorDebugInfo();
     lastDebugPrint = now;
   }
+#endif
 }

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -1,5 +1,7 @@
 #include "backlight.h"
 
+#include <M5CoreS3.h>
+
 #include <algorithm>
 #include <cstring>
 
@@ -40,14 +42,13 @@ void applyBrightnessMode(BrightnessMode mode)
 // ────────────────────── 輝度更新 ──────────────────────
 void updateBacklightLevel()
 {
-  if (!SENSOR_AMBIENT_LIGHT_PRESENT)
+#if !SENSOR_AMBIENT_LIGHT_PRESENT
+  if (currentBrightnessMode != BrightnessMode::Day)
   {
-    if (currentBrightnessMode != BrightnessMode::Day)
-    {
-      applyBrightnessMode(BrightnessMode::Day);
-    }
-    return;
+    applyBrightnessMode(BrightnessMode::Day);
   }
+  return;
+#endif
 
   int currentLux = CoreS3.Ltr553.getAlsValue();
   latestLux = currentLux;
@@ -59,10 +60,9 @@ void updateBacklightLevel()
   medianLuxValue = medianLux;
 
   // デバッグモードでは照度を出力
-  if (DEBUG_MODE_ENABLED)
-  {
-    Serial.printf("[ALS] lux:%u, median:%u\n", currentLux, medianLux);
-  }
+#if DEBUG_MODE_ENABLED
+  Serial.printf("[ALS] lux:%u, median:%u\n", currentLux, medianLux);
+#endif
 
   BrightnessMode newMode = (medianLux >= LUX_THRESHOLD_DAY)    ? BrightnessMode::Day
                            : (medianLux >= LUX_THRESHOLD_DUSK) ? BrightnessMode::Dusk

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -160,11 +160,10 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
                      recordedMaxOilPressure, prevPressureValue, 0.5f, isUseDecimal, 0, 60, false);
   }
   bool fpsChanged = false;
-  if (FPS_DISPLAY_ENABLED)
-  {
-    // FPS表示が有効な場合のみ描画する
-    fpsChanged = drawFpsOverlay();
-  }
+#if FPS_DISPLAY_ENABLED
+  // FPS表示が有効な場合のみ描画する
+  fpsChanged = drawFpsOverlay();
+#endif
   bool racingChanged = drawRacingIndicator(mainCanvas);
 
   // 値が更新されたときのみスプライトを転送する
@@ -231,11 +230,10 @@ void updateGauges()
 
   float oilTempValue = smoothOilTemp;
   float pressureValue = smoothOilPressure;
-  if (!SENSOR_OIL_TEMP_PRESENT)
-  {
-    // センサーが無い場合は常に 0 表示
-    oilTempValue = 0.0F;
-  }
+#if !SENSOR_OIL_TEMP_PRESENT
+  // センサーが無い場合は常に 0 表示
+  oilTempValue = 0.0F;
+#endif
 
   recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
   recordedMaxWaterTemp = std::max(recordedMaxWaterTemp, smoothWaterTemp);
@@ -262,58 +260,51 @@ void drawMenuScreen()
   constexpr int MENU_BOTTOM_MARGIN = 40;  // 下端の余白（戻る案内分）
   // 表示行数を減らして行間を確保
   // OIL.P WARN の詳細表示を2行で確保するため1行分多く確保
-  constexpr int MENU_LINES = SENSOR_AMBIENT_LIGHT_PRESENT ? 7 : 5;                          // 表示行数
+#if SENSOR_AMBIENT_LIGHT_PRESENT
+  constexpr int MENU_LINES = 7;  // 表示行数
+#else
+  constexpr int MENU_LINES = 5;  // 表示行数
+#endif
   const int lineHeight = (LCD_HEIGHT - MENU_TOP_MARGIN - MENU_BOTTOM_MARGIN) / MENU_LINES;  // 行間
 
   int y = MENU_TOP_MARGIN;
+  char valStr[8];  // 数値表示用バッファ
 
   // 最高水温を表示
   mainCanvas.setCursor(10, y);
   mainCanvas.print("WATER.T MAX:");
-  if (SENSOR_WATER_TEMP_PRESENT)
-  {
-    char valStr[8];
-    // 小数点を表示しない
-    snprintf(valStr, sizeof(valStr), "%6.0f", recordedMaxWaterTemp);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-  else
-  {
-    // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
-  }
+#if SENSOR_WATER_TEMP_PRESENT
+  // 小数点を表示しない
+  snprintf(valStr, sizeof(valStr), "%6.0f", recordedMaxWaterTemp);
+  mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+#else
+  // センサー無効時は Disabled と表示
+  mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
+#endif
 
   y += lineHeight;
   // 最高油温を表示
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.T MAX:");
-  if (SENSOR_OIL_TEMP_PRESENT)
-  {
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6d", recordedMaxOilTempTop);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-  else
-  {
-    // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
-  }
+#if SENSOR_OIL_TEMP_PRESENT
+  snprintf(valStr, sizeof(valStr), "%6d", recordedMaxOilTempTop);
+  mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+#else
+  // センサー無効時は Disabled と表示
+  mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
+#endif
 
   y += lineHeight;
   // 最高油圧を表示
   mainCanvas.setCursor(10, y);
   mainCanvas.print("OIL.P MAX:");
-  if (SENSOR_OIL_PRESSURE_PRESENT)
-  {
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxOilPressure);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
-  }
-  else
-  {
-    // センサー無効時は Disabled と表示
-    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
-  }
+#if SENSOR_OIL_PRESSURE_PRESENT
+  snprintf(valStr, sizeof(valStr), "%6.1f", recordedMaxOilPressure);
+  mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+#else
+  // センサー無効時は Disabled と表示
+  mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
+#endif
 
   y += lineHeight;
   // 直近の低油圧イベント情報を2行で表示
@@ -359,33 +350,29 @@ void drawMenuScreen()
 
   y += lineHeight;
   mainCanvas.setCursor(10, y);
-  if (SENSOR_AMBIENT_LIGHT_PRESENT)
-  {
-    // 現在のLUX値を表示
-    mainCanvas.print("LUX LATEST:");
-    char valStr[8];
-    snprintf(valStr, sizeof(valStr), "%6d", latestLux);
-    mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
+#if SENSOR_AMBIENT_LIGHT_PRESENT
+  // 現在のLUX値を表示
+  mainCanvas.print("LUX LATEST:");
+  snprintf(valStr, sizeof(valStr), "%6d", latestLux);
+  mainCanvas.drawRightString(valStr, LCD_WIDTH - 10, y);
 
-    y += lineHeight;
-    mainCanvas.setCursor(10, y);
-    // 照度の中央値を表示
-    mainCanvas.print("LUX MEDIAN:");
-    char medStr[8];
-    snprintf(medStr, sizeof(medStr), "%6d", medianLuxValue);
-    mainCanvas.drawRightString(medStr, LCD_WIDTH - 10, y);
-  }
-  else
-  {
-    // LUX センサーが無い場合は両方 Disabled を表示
-    mainCanvas.print("LUX LATEST:");
-    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
+  y += lineHeight;
+  mainCanvas.setCursor(10, y);
+  // 照度の中央値を表示
+  mainCanvas.print("LUX MEDIAN:");
+  char medStr[8];
+  snprintf(medStr, sizeof(medStr), "%6d", medianLuxValue);
+  mainCanvas.drawRightString(medStr, LCD_WIDTH - 10, y);
+#else
+  // LUX センサーが無い場合は両方 Disabled を表示
+  mainCanvas.print("LUX LATEST:");
+  mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
 
-    y += 25;
-    mainCanvas.setCursor(10, y);
-    mainCanvas.print("LUX MEDIAN:");
-    mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
-  }
+  y += 25;
+  mainCanvas.setCursor(10, y);
+  mainCanvas.print("LUX MEDIAN:");
+  mainCanvas.drawRightString(DISABLED_STR, LCD_WIDTH - 10, y);
+#endif
 
   // 戻る案内を左下へ配置
   mainCanvas.setCursor(10, LCD_HEIGHT - 20);

--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -12,11 +12,10 @@ static unsigned long lastFpsDrawTime = 0;
 // ────────────────────── FPS表示 ──────────────────────
 auto drawFpsOverlay() -> bool
 {
-  if (!FPS_DISPLAY_ENABLED)
-  {
-    // FPS表示が無効な場合は何もしない
-    return false;
-  }
+#if !FPS_DISPLAY_ENABLED
+  // FPS表示が無効な場合は何もしない
+  return false;
+#endif
 
   mainCanvas.setFont(&fonts::Font0);
   mainCanvas.setTextSize(0);

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -2,7 +2,9 @@
 #define SENSOR_H
 
 #include <Adafruit_ADS1X15.h>
-#include <stdint.h>
+
+#include <cstddef>
+#include <cstdint>
 
 #include "config.h"
 


### PR DESCRIPTION
## Summary
- 共通の数値バッファを一度だけ宣言し、メニュー描画での再宣言エラーを解消
- 設定のブール値を `#define` と条件コンパイルに変更し、不要処理をビルドから除外
- ハードウェア依存ヘッダを `config.h` から削除し、`backlight.cpp` に個別インクルード

## Testing
- `git pull && git merge main` (no tracking info, already up to date)
- `clang-format -i include/config.h src/modules/backlight.cpp`
- `clang-tidy include/config.h src/modules/backlight.cpp -- -std=c++17` (missing headers and many warnings)
- `act -j build` (command not found)
- `platformio run` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba68a733008322a88d666bca3d3687