### PR TITLE
詳細画面表示時にレーシングモードを解除 / Disable racing mode on detail screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,7 +132,8 @@ void loop()
     isMenuVisible = !isMenuVisible;
     if (isMenuVisible)
     {
-      previousBrightnessMode = currentBrightnessMode;  // 現在の輝度モードを保存
+      previousBrightnessMode = isRacingMode ? racingPrevMode : currentBrightnessMode;  // 現在の輝度モードを保存
+      isRacingMode = false;                                                            // 詳細画面ではレーシングモードを解除
       drawMenuScreen();
       // メニュー表示中は輝度を最大にする
       applyBrightnessMode(BrightnessMode::Day);


### PR DESCRIPTION
## Summary
- 詳細画面へ移行した際にレーシングモードを解除
- レーシングモード中の輝度モードを正しく復元

## Testing
- `clang-format -i src/main.cpp`
- `clang-tidy src/main.cpp --` *(fails: 'M5CoreS3.h' file not found)*
- `act -j build` *(command not found; apt package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc34f9eb048322b999aa693073cc98