### PR TITLE
メニュー表示時にレーシングモードを解除 / Disable racing mode when menu opens

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,6 +134,7 @@ void loop()
     {
       previousBrightnessMode = isRacingMode ? racingPrevMode : currentBrightnessMode;  // 現在の輝度モードを保存
       isRacingMode = false;                                                            // 詳細画面ではレーシングモードを解除
+      racingStartMs = 0;  // レーシングモードのタイマーをリセット
       drawMenuScreen();
       // メニュー表示中は輝度を最大にする
       applyBrightnessMode(BrightnessMode::Day);


### PR DESCRIPTION
## Summary
- メニュー表示時にレーシングモードのタイマーをリセットして、レースモードを確実に解除

## Testing
- `clang-format -i src/main.cpp`
- `clang-tidy src/main.cpp -- -Iinclude` *(missing header: M5CoreS3.h)*
- `act -j build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be6fb114108322a6bb4706e3187d34