### PR TITLE
AXP2101警告を黒画面に表示して処理停止 / Display AXP2101 warnings on black screen and halt

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "config.h"
 #include "modules/backlight.h"
 #include "modules/display.h"
+#include "modules/power_monitor.h"
 #include "modules/racing_indicator.h"
 #include "modules/sensor.h"
 
@@ -47,6 +48,7 @@ void setup()
   M5.Power.begin();              // まず電源モジュールを初期化
   M5.Power.setExtOutput(false);  // 外部給電時は 5V ピン出力を停止
   M5.Power.setUsbOutput(false);  // USB 給電を停止
+  initPowerMonitor();            // 電源警告の初期化
 
   display.init();
   // DMA を初期化
@@ -119,6 +121,7 @@ void loop()
   unsigned long now = millis();
 
   M5.update();
+  checkPowerWarnings();  // 電源ICの警告を監視
 
   if (!isMenuVisible && !isRacingMode && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
   {

--- a/src/modules/power_monitor.cpp
+++ b/src/modules/power_monitor.cpp
@@ -1,0 +1,59 @@
+#include "power_monitor.h"
+
+#include <M5CoreS3.h>
+
+#include "config.h"
+
+// AXP2101の警告を有効化し初期化
+void initPowerMonitor()
+{
+  uint64_t irqMask = AXP2101_IRQ_LDO_OVER_CURR | AXP2101_IRQ_BATFET_OVER_CURR | AXP2101_IRQ_BAT_OVER_VOLTAGE |
+                     AXP2101_IRQ_WARNING_LEVEL1 | AXP2101_IRQ_WARNING_LEVEL2;
+  M5.Power.Axp2101.enableIRQ(irqMask);
+  M5.Power.Axp2101.clearIRQStatuses();
+}
+
+// AXP2101から警告を取得し画面に表示して停止
+void checkPowerWarnings()
+{
+  uint64_t status = M5.Power.Axp2101.getIRQStatuses();
+  if (status == 0)
+  {
+    return;
+  }
+
+  // 画面を黒で塗りつぶしエラー内容を表示
+  M5.Lcd.fillScreen(COLOR_BLACK);
+  M5.Lcd.setCursor(0, 0);
+  M5.Lcd.setTextColor(COLOR_RED);
+
+  if (status & AXP2101_IRQ_LDO_OVER_CURR)
+  {
+    M5.Lcd.println("[Power] LDO over-current");
+  }
+  if (status & AXP2101_IRQ_BATFET_OVER_CURR)
+  {
+    M5.Lcd.println("[Power] BATFET over-current");
+  }
+  if (status & AXP2101_IRQ_BAT_OVER_VOLTAGE)
+  {
+    M5.Lcd.println("[Power] Battery over-voltage");
+  }
+  if (status & AXP2101_IRQ_WARNING_LEVEL1)
+  {
+    M5.Lcd.println("[Power] Warning level 1 (low battery)");
+  }
+  if (status & AXP2101_IRQ_WARNING_LEVEL2)
+  {
+    M5.Lcd.println("[Power] Warning level 2 (critical battery)");
+  }
+
+  M5.Power.Axp2101.clearIRQStatuses();
+
+  // 無限ループで以降の処理を停止
+  const uint16_t errorLoopDelayMs = 1000;  // 遅延時間 (ms)
+  while (true)
+  {
+    delay(errorLoopDelayMs);
+  }
+}

--- a/src/modules/power_monitor.h
+++ b/src/modules/power_monitor.h
@@ -1,0 +1,9 @@
+#ifndef POWER_MONITOR_H
+#define POWER_MONITOR_H
+
+// AXP2101の警告を初期化
+void initPowerMonitor();
+// AXP2101の警告を確認して画面に表示し停止
+void checkPowerWarnings();
+
+#endif  // POWER_MONITOR_H

--- a/test/ci_dummy/M5CoreS3.h
+++ b/test/ci_dummy/M5CoreS3.h
@@ -1,0 +1,60 @@
+#ifndef M5CORES3_H
+#define M5CORES3_H
+
+#include <cstdint>
+
+// AXP2101に対するスタブクラス
+struct MockAXP2101
+{
+  uint64_t irqMask = 0;      // 設定されたIRQマスク
+  uint64_t irqStatus = 0;    // 取得するIRQステータス
+  bool clearCalled = false;  // クリアが呼び出されたか
+
+  void enableIRQ(uint64_t mask) { irqMask = mask; }
+  void clearIRQStatuses() { clearCalled = true; }
+  uint64_t getIRQStatuses() { return irqStatus; }
+};
+
+// 電源周りのスタブ
+struct MockPower
+{
+  MockAXP2101 Axp2101;
+};
+
+// 画面制御のスタブ
+struct MockLcd
+{
+  bool fillCalled = false;     // 画面塗りつぶしが呼ばれたか
+  bool printlnCalled = false;  // 文字表示が呼ばれたか
+  uint16_t lastFillColor = 0;  // 最後に塗りつぶした色
+
+  void fillScreen(uint16_t color)
+  {
+    fillCalled = true;
+    lastFillColor = color;
+  }
+  void setCursor(int, int) {}
+  void setTextColor(uint16_t) {}
+  void println(const char*) { printlnCalled = true; }
+};
+
+// M5本体のスタブ
+struct MockM5
+{
+  MockPower Power;
+  MockLcd Lcd;
+};
+
+extern MockM5 M5;  // グローバルインスタンス
+
+// Arduino互換のdelay関数スタブ
+inline void delay(uint16_t) {}
+
+// AXP2101のIRQビット定義
+constexpr uint64_t AXP2101_IRQ_LDO_OVER_CURR = 1ULL << 0;
+constexpr uint64_t AXP2101_IRQ_BATFET_OVER_CURR = 1ULL << 1;
+constexpr uint64_t AXP2101_IRQ_BAT_OVER_VOLTAGE = 1ULL << 2;
+constexpr uint64_t AXP2101_IRQ_WARNING_LEVEL1 = 1ULL << 3;
+constexpr uint64_t AXP2101_IRQ_WARNING_LEVEL2 = 1ULL << 4;
+
+#endif  // M5CORES3_H

--- a/test/ci_dummy/test_power_monitor.cpp
+++ b/test/ci_dummy/test_power_monitor.cpp
@@ -1,0 +1,41 @@
+#include <unity.h>
+
+// スタブヘッダーと対象モジュールをインクルード
+// clang-format off
+#include "M5CoreS3.h"
+#include "../../src/modules/power_monitor.cpp"
+// clang-format on
+
+MockM5 M5;  // スタブの実体
+
+// initPowerMonitor の動作を確認
+void test_init_power_monitor()
+{
+  initPowerMonitor();
+  uint64_t expected = AXP2101_IRQ_LDO_OVER_CURR | AXP2101_IRQ_BATFET_OVER_CURR | AXP2101_IRQ_BAT_OVER_VOLTAGE |
+                      AXP2101_IRQ_WARNING_LEVEL1 | AXP2101_IRQ_WARNING_LEVEL2;
+  TEST_ASSERT_EQUAL_UINT64(expected, M5.Power.Axp2101.irqMask);
+  TEST_ASSERT_TRUE(M5.Power.Axp2101.clearCalled);
+}
+
+// 警告がない場合に何もしないことを確認
+void test_check_power_warnings_no_status()
+{
+  M5.Power.Axp2101.irqStatus = 0;
+  checkPowerWarnings();
+  TEST_ASSERT_FALSE(M5.Lcd.fillCalled);
+  TEST_ASSERT_FALSE(M5.Lcd.printlnCalled);
+}
+
+void setup()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_init_power_monitor);
+  RUN_TEST(test_check_power_warnings_no_status);
+  UNITY_END();
+}
+
+void loop()
+{
+  // ループ処理は不要
+}


### PR DESCRIPTION
## 概要 / Summary
- AXP2101の警告発生時に画面を黒くして警告メッセージを表示し、その後の処理を停止
- DEBUG_MODE_ENABLED が無効でも同様に動作

## テスト / Testing
- `clang-format -i src/modules/power_monitor.h src/modules/power_monitor.cpp src/main.cpp`
- `clang-tidy src/modules/power_monitor.cpp src/modules/power_monitor.h src/main.cpp --` (ヘッダー未検出により失敗)
- `act -j build` (act 未インストールのため実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68befaa2a5cc832294090de7d5c62822