### PR TITLE
drawFillArcMeterの未使用パラメータ削除 / Remove unused parameter from drawFillArcMeter

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -17,8 +17,8 @@ static inline T clampValue(T val, T low, T high)
   return val;
 }
 
-void drawFillArcMeter(M5Canvas /*unused*/ &canvas, float value, float minValue, float maxValue, float threshold,
-                      uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,
+void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxValue, float threshold,
+                      uint16_t overThresholdColor, const char *unit, const char *label,
                       float &previousValue,  // 前回描画した値
                       float tickStep,        // 目盛の間隔（細かい目盛り）
                       bool isUseDecimal,     // 小数点を表示するかどうか

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -132,7 +132,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
     }
     bool isUseDecimal = pressureAvg < 9.95F;
     drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "x100kPa", "OIL.P",
-                     recordedMaxOilPressure, prevPressureValue, 0.5f, isUseDecimal, 0, 60, !pressureGaugeInitialized);
+                     prevPressureValue, 0.5f, isUseDecimal, 0, 60, !pressureGaugeInitialized);
     pressureGaugeInitialized = true;
     displayCache.pressureAvg = pressureAvg;
   }
@@ -144,8 +144,8 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
       mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
     }
     drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 110.0f, COLOR_RED, "Celsius",
-                     "WATER.T", recordedMaxWaterTemp, prevWaterTempValue, 1.0f, false, 160, 60, !waterGaugeInitialized,
-                     5.0f, WATER_TEMP_METER_MIN);
+                     "WATER.T", prevWaterTempValue, 1.0f, false, 160, 60, !waterGaugeInitialized, 5.0f,
+                     WATER_TEMP_METER_MIN);
     waterGaugeInitialized = true;
     displayCache.waterTempAvg = waterTempAvg;
   }
@@ -157,7 +157,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
     // 警告が消えたら油圧ゲージを再描画して元に戻す
     bool isUseDecimal = pressureAvg < 9.95F;
     drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, MAX_OIL_PRESSURE_METER, 8.0f, COLOR_RED, "x100kPa", "OIL.P",
-                     recordedMaxOilPressure, prevPressureValue, 0.5f, isUseDecimal, 0, 60, false);
+                     prevPressureValue, 0.5f, isUseDecimal, 0, 60, false);
   }
   bool fpsChanged = false;
 #if FPS_DISPLAY_ENABLED


### PR DESCRIPTION
### 日本語
- drawFillArcMeter から使われていない maxRecordedValue 引数を削除しました。
- 呼び出し箇所を整理し、不要な記述をなくしました。

### English
- Removed unused `maxRecordedValue` parameter from `drawFillArcMeter`.
- Cleaned up call sites to eliminate the unused argument.

------
https://chatgpt.com/codex/tasks/task_e_68c3ca4bf8848322bc568ac6b209f4bb