### PR TITLE
PRレビューを日本語で行う指示を追加 / Add instruction to conduct PR reviews in Japanese

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
   - リファクタ: `react/` プレフィックスを使用 / For refactoring, use the `react/` prefix.
 - プルリクエストのタイトルと概要は、日本語と英語の二言語で記述してください。/ Provide PR titles and descriptions in both Japanese and English.
 - コード中のコメントは日本語で記述してください。/ Write code comments in Japanese.
-- レビューコメントは日本語で返してください。/ Respond to review comments in Japanese.
+- PRレビューやレビューコメントは日本語で返してください。/ Provide PR reviews and review comments in Japanese.
 - コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
 - 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.
 - コードを変更したら `act -j build` を実行してCIを確認し、プッシュ後は GitHub Actions の終了を待ち、エラーがあれば修正して再度プッシュしてください。/ After modifying code, run `act -j build` to check CI locally. After pushing, wait for GitHub Actions to finish and push again if errors occur.


### PR DESCRIPTION
## Summary
- PRレビューやレビューコメントを日本語で行う指示をAGENTS.mdに追加しました。
- Add guidance in AGENTS.md that PR reviews and review comments should be in Japanese.

## Testing
- `clang-format -i $(git ls-files '*.cpp' '*.h')`
- `clang-tidy $(git ls-files '*.cpp') -- -I.` (fails: multiple warnings and errors)
- `act -j build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c4e10b06d48322b5b1359a092faf5e