### PR TITLE
レーシングモード開始の持続判定を0.1秒に短縮 / Shorten racing mode activation delay to 0.1s

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -77,6 +77,13 @@ constexpr uint8_t BACKLIGHT_NIGHT = 60;
 
 constexpr int MEDIAN_BUFFER_SIZE = 10;
 
+// レーシングモード継続時間 [ms]
+constexpr unsigned long RACING_MODE_DURATION_MS = 180000UL;
+// 静止時の加速度との差がこの値を超えたらレーシングモードを延長・開始する [g]
+constexpr float RACING_MODE_ACCEL_THRESHOLD_G = 1.0F;
+// 加速度が閾値を0.1秒以上超えたらレーシングモードを開始する [ms]
+constexpr unsigned long RACING_MODE_START_DELAY_MS = 100UL;
+
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;
 

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -202,9 +202,12 @@ void updateGauges()
     oilTempValue = 0.0F;
   }
 
-  recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
-  recordedMaxWaterTemp = std::max(recordedMaxWaterTemp, smoothWaterTemp);
-  recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
+  if (racingModeActive)
+  {
+    recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
+    recordedMaxWaterTemp = std::max(recordedMaxWaterTemp, smoothWaterTemp);
+    recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
+  }
 
   renderDisplayAndLog(pressureValue, smoothWaterTemp, oilTempValue, recordedMaxOilTempTop);
 }

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -9,6 +9,10 @@
 extern M5GFX display;
 extern M5Canvas mainCanvas;
 extern int currentFps;
+extern float recordedMaxOilPressure;
+extern float recordedMaxWaterTemp;
+extern int recordedMaxOilTempTop;
+extern bool racingModeActive;
 
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp);
 void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp);

--- a/src/modules/racing_mode.cpp
+++ b/src/modules/racing_mode.cpp
@@ -1,0 +1,52 @@
+#include "racing_mode.h"
+
+#include <cmath>
+
+// レーシングモード継続判定と延長処理
+bool updateRacingMode(unsigned long &startTime, unsigned long now, float ax, float ay, float az, float baseAx, float baseAy,
+                      float baseAz)
+{
+  float dx = ax - baseAx;  // 静止時との差分
+  float dy = ay - baseAy;
+  float dz = az - baseAz;
+  // ルート計算を避けるため二乗値で比較
+  float diffSq = dx * dx + dy * dy + dz * dz;
+  float thresholdSq = RACING_MODE_ACCEL_THRESHOLD_G * RACING_MODE_ACCEL_THRESHOLD_G;
+  if (diffSq >= thresholdSq)
+  {
+    startTime = now;  // 1g超過で時間延長
+  }
+  if (now - startTime >= RACING_MODE_DURATION_MS)
+  {
+    return false;  // 規定時間経過で終了
+  }
+  return true;  // 継続
+}
+
+// 0.1秒以上加速度が閾値を超えたかを判定
+bool shouldStartRacingMode(unsigned long &overStart, unsigned long now, float ax, float ay, float az, float baseAx,
+                           float baseAy, float baseAz)
+{
+  float dx = ax - baseAx;  // 静止時との差分
+  float dy = ay - baseAy;
+  float dz = az - baseAz;
+  float diffSq = dx * dx + dy * dy + dz * dz;
+  float thresholdSq = RACING_MODE_ACCEL_THRESHOLD_G * RACING_MODE_ACCEL_THRESHOLD_G;
+  if (diffSq >= thresholdSq)
+  {
+    if (overStart == 0)
+    {
+      overStart = now;  // 閾値超過開始時刻を記録
+    }
+    else if (now - overStart >= RACING_MODE_START_DELAY_MS)
+    {
+      overStart = 0;  // 判定用タイマーをリセット
+      return true;    // レーシングモードを開始
+    }
+  }
+  else
+  {
+    overStart = 0;  // 閾値未満ならタイマーをリセット
+  }
+  return false;  // まだ開始しない
+}

--- a/src/modules/racing_mode.h
+++ b/src/modules/racing_mode.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "config.h"
+
+// レーシングモードの状態更新と延長判定を行う
+// baseAx/baseAy/baseAz は静止時の基準加速度
+bool updateRacingMode(unsigned long &startTime, unsigned long now, float ax, float ay, float az, float baseAx, float baseAy,
+                      float baseAz);
+
+// 加速度が閾値を一定時間超えているかを判定し、レーシングモード開始の可否を返す
+// baseAx/baseAy/baseAz は静止時の基準加速度
+bool shouldStartRacingMode(unsigned long &overStart, unsigned long now, float ax, float ay, float az, float baseAx,
+                           float baseAy, float baseAz);

--- a/test/ci_dummy/test_racing_mode.cpp
+++ b/test/ci_dummy/test_racing_mode.cpp
@@ -1,0 +1,61 @@
+#include <unity.h>
+
+#include "../../src/modules/racing_mode.h"
+
+// 静止時の基準加速度
+constexpr float BASE_AX = 0.0f;
+constexpr float BASE_AY = 0.0f;
+constexpr float BASE_AZ = 1.0f;
+
+// 自動終了のテスト
+void test_auto_timeout()
+{
+  unsigned long start = 0;
+  bool active = updateRacingMode(start, RACING_MODE_DURATION_MS + 1, BASE_AX, BASE_AY, BASE_AZ, BASE_AX, BASE_AY, BASE_AZ);
+  TEST_ASSERT_FALSE(active);
+}
+
+// 加速度による延長のテスト
+void test_extension_by_accel()
+{
+  unsigned long start = 0;
+  unsigned long now = RACING_MODE_DURATION_MS - 1;
+  bool active = updateRacingMode(start, now, BASE_AX + RACING_MODE_ACCEL_THRESHOLD_G + 0.1f, BASE_AY, BASE_AZ, BASE_AX,
+                                 BASE_AY, BASE_AZ);
+  TEST_ASSERT_TRUE(active);
+  active =
+      updateRacingMode(start, start + RACING_MODE_DURATION_MS - 1, BASE_AX, BASE_AY, BASE_AZ, BASE_AX, BASE_AY, BASE_AZ);
+  TEST_ASSERT_TRUE(active);
+  active =
+      updateRacingMode(start, start + RACING_MODE_DURATION_MS + 1, BASE_AX, BASE_AY, BASE_AZ, BASE_AX, BASE_AY, BASE_AZ);
+  TEST_ASSERT_FALSE(active);
+}
+
+// 0.1秒継続でレーシングモード開始するテスト
+void test_start_after_delay()
+{
+  unsigned long over = 0;
+  bool start = shouldStartRacingMode(over, 0, BASE_AX + RACING_MODE_ACCEL_THRESHOLD_G + 0.1f, BASE_AY, BASE_AZ, BASE_AX,
+                                     BASE_AY, BASE_AZ);
+  TEST_ASSERT_FALSE(start);
+  start = shouldStartRacingMode(over, RACING_MODE_START_DELAY_MS - 1, BASE_AX + RACING_MODE_ACCEL_THRESHOLD_G + 0.1f,
+                                BASE_AY, BASE_AZ, BASE_AX, BASE_AY, BASE_AZ);
+  TEST_ASSERT_FALSE(start);
+  start = shouldStartRacingMode(over, RACING_MODE_START_DELAY_MS, BASE_AX + RACING_MODE_ACCEL_THRESHOLD_G + 0.1f, BASE_AY,
+                                BASE_AZ, BASE_AX, BASE_AY, BASE_AZ);
+  TEST_ASSERT_TRUE(start);
+}
+
+void setup()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_auto_timeout);
+  RUN_TEST(test_extension_by_accel);
+  RUN_TEST(test_start_after_delay);
+  UNITY_END();
+}
+
+void loop()
+{
+  // テストでは使用しない
+}


### PR DESCRIPTION
## Summary
- 加速度が1gを0.1秒以上超えた場合のみレーシングモードを開始 / Activate racing mode only after acceleration exceeds 1g for 0.1 seconds
- テストの説明文も0.1秒に合わせて更新 / Update test descriptions to reflect 0.1-second delay
- 静止時1Gを基準にしたコメントとテストへ修正 / Clarify baseline acceleration as 1G and adjust tests

## Testing
- `clang-format -i include/config.h src/modules/racing_mode.h src/modules/racing_mode.cpp src/main.cpp test/ci_dummy/test_racing_mode.cpp`
- `clang-tidy include/config.h src/modules/racing_mode.cpp src/modules_racing_mode.h src/main.cpp test/ci_dummy/test_racing_mode.cpp -- -Iinclude -Isrc` (failed: 'M5CoreS3.h' file not found and many warnings)
- `pio test -e m5stack-cores3-ci` (failed: HTTPClientError)

Reviewer: @copilot

------
https://chatgpt.com/codex/tasks/task_e_68bd00da4dd483229537e0a0771a6e91