### PR TITLE
Copilotレビューコメント方針の追加 / Add policy for Copilot review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 - プルリクエストのタイトルと概要は、日本語と英語の二言語で記述してください。/ Provide PR titles and descriptions in both Japanese and English.
 - コード中のコメントは日本語で記述してください。/ Write code comments in Japanese.
 - PRレビューやレビューコメントは日本語で返してください。/ Provide PR reviews and review comments in Japanese.
+- Copilot のレビューコメントは日本語で行い、以下の重要度区分を使用してください。/ Write Copilot review comments in Japanese and use the following importance levels.
+  - [MUST]: 不具合やメンテコストを意識すると修正が必須 / Fix is mandatory when considering bugs or maintenance costs.
+  - [IMO★3]: できれば修正したい内容 / Prefer to fix; mark with ★3.
+  - [NITS]: 細かい指摘で、サジェストを承認すればすぐ修正できる形式にしてください。/ Minor suggestions that should be provided in an easily applicable suggestion format.
 - コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
 - 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.
 - コードを変更したら `act -j build` を実行してCIを確認し、プッシュ後は GitHub Actions の終了を待ち、エラーがあれば修正して再度プッシュしてください。/ After modifying code, run `act -j build` to check CI locally. After pushing, wait for GitHub Actions to finish and push again if errors occur.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - PRレビューやレビューコメントは日本語で返してください。/ Provide PR reviews and review comments in Japanese.
 - Copilot のレビューコメントは日本語で行い、以下の重要度区分を使用してください。/ Write Copilot review comments in Japanese and use the following importance levels.
   - [MUST]: 不具合やメンテコストを意識すると修正が必須 / Fix is mandatory when considering bugs or maintenance costs.
-  - [IMO★3]: できれば修正したい内容 / Prefer to fix; mark with ★3.
+  - [IMO] ★☆☆: できれば修正したい内容を☆の数で表現する / Prefer to fix; mark with ★★☆(ex.)
   - [NITS]: 細かい指摘で、サジェストを承認すればすぐ修正できる形式にしてください。/ Minor suggestions that should be provided in an easily applicable suggestion format.
 - コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
 - 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.


### PR DESCRIPTION
## Summary
- AGENTS.md に Copilot のレビューコメント方針を追記
- Added guidelines for Copilot review comments in AGENTS.md

## Testing
- `clang-format -i AGENTS.md`
- `clang-tidy AGENTS.md` (compilation database not found)
- `act -j build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c4e5a25ef883228273ed20905e6d8d