### PR TITLE
フレームレートの上限を30FPSに変更 / Limit frame rate to 30 FPS

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -3,8 +3,6 @@
 
 #include <cstdint>  // 整数型定義
 
-#include <cstdint>  // 整数型定義
-
 // ────────────────────── 設定 ──────────────────────
 // デバッグ用メッセージ表示の有無
 #define DEBUG_MODE_ENABLED 0
@@ -88,8 +86,8 @@ constexpr unsigned long RACING_MODE_DURATION_MS = 180000UL;
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;
 
-// 最大60FPSに制御するためのフレーム間隔 [us]
-constexpr unsigned long FRAME_INTERVAL_US = 1000000UL / 60;
+// 最大30FPSに制御するためのフレーム間隔 [us]
+constexpr unsigned long FRAME_INTERVAL_US = 1000000UL / 30;
 
 // ── ADS1015 のチャンネル定義 ──
 constexpr uint8_t ADC_CH_WATER_TEMP = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ void loop()
 {
   static unsigned long lastAlsMeasurementTime = 0;
   unsigned long nowUs = micros();
-  // 前のフレームから16.6ms未満なら待機
+  // 前のフレームから33.3ms未満なら待機
   if (lastFrameTimeUs != 0 && nowUs - lastFrameTimeUs < FRAME_INTERVAL_US)
   {
     delayMicroseconds(FRAME_INTERVAL_US - (nowUs - lastFrameTimeUs));


### PR DESCRIPTION
## Summary / 概要
- フレーム間隔を調整して30FPSに制限
- 関連コメントを30FPS向けに更新

## Testing / テスト
- `clang-format -i include/config.h src/main.cpp`
- `clang-tidy include/config.h src/main.cpp -- -Iinclude` (エラー: 'cstdint' file not found など)
- `act -j build` (コマンドが見つからないため実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68c574c32c048322ac16b4262ce9f8ac