### PR TITLE
Show error screen on loop exceptions / ループ例外時にエラー画面を表示

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,100 +110,118 @@ void setup()
 void loop()
 {
   static unsigned long lastAlsMeasurementTime = 0;
-  unsigned long nowUs = micros();
-  // 前のフレームから16.6ms未満なら待機
-  if (lastFrameTimeUs != 0 && nowUs - lastFrameTimeUs < FRAME_INTERVAL_US)
+  try
   {
-    delayMicroseconds(FRAME_INTERVAL_US - (nowUs - lastFrameTimeUs));
-    nowUs = micros();
-  }
-  lastFrameTimeUs = nowUs;
-  unsigned long now = millis();
-
-  M5.update();
-
-  if (!isMenuVisible && !isRacingMode && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
-  {
-    updateBacklightLevel();
-    lastAlsMeasurementTime = now;
-  }
-
-  bool touched = M5.Touch.getCount() > 0;
-  if (touched && !wasTouched)
-  {
-    isMenuVisible = !isMenuVisible;
-    if (isMenuVisible)
+    unsigned long nowUs = micros();
+    // 前のフレームから16.6ms未満なら待機
+    if (lastFrameTimeUs != 0 && nowUs - lastFrameTimeUs < FRAME_INTERVAL_US)
     {
-      previousBrightnessMode = isRacingMode ? racingPrevMode : currentBrightnessMode;  // 現在の輝度モードを保存
-      isRacingMode = false;                                                            // 詳細画面ではレーシングモードを解除
-      racingStartMs = 0;  // レーシングモードのタイマーをリセット
-      drawMenuScreen();
-      // メニュー表示中は輝度を最大にする
-      applyBrightnessMode(BrightnessMode::Day);
+      delayMicroseconds(FRAME_INTERVAL_US - (nowUs - lastFrameTimeUs));
+      nowUs = micros();
     }
-    else
+    lastFrameTimeUs = nowUs;
+    unsigned long now = millis();
+
+    M5.update();
+
+    if (!isMenuVisible && !isRacingMode && now - lastAlsMeasurementTime >= ALS_MEASUREMENT_INTERVAL_MS)
     {
-      resetGaugeState();
-      // メニュー終了後は元の輝度に戻す
-#if SENSOR_AMBIENT_LIGHT_PRESENT
-      if (isRacingMode)
+      updateBacklightLevel();
+      lastAlsMeasurementTime = now;
+    }
+
+    bool touched = M5.Touch.getCount() > 0;
+    if (touched && !wasTouched)
+    {
+      isMenuVisible = !isMenuVisible;
+      if (isMenuVisible)
       {
+        previousBrightnessMode = isRacingMode ? racingPrevMode : currentBrightnessMode;  // 現在の輝度モードを保存
+        isRacingMode = false;  // 詳細画面ではレーシングモードを解除
+        racingStartMs = 0;     // レーシングモードのタイマーをリセット
+        drawMenuScreen();
+        // メニュー表示中は輝度を最大にする
         applyBrightnessMode(BrightnessMode::Day);
       }
       else
       {
-        updateBacklightLevel();
-      }
+        resetGaugeState();
+        // メニュー終了後は元の輝度に戻す
+#if SENSOR_AMBIENT_LIGHT_PRESENT
+        if (isRacingMode)
+        {
+          applyBrightnessMode(BrightnessMode::Day);
+        }
+        else
+        {
+          updateBacklightLevel();
+        }
 #else
-      applyBrightnessMode(isRacingMode ? BrightnessMode::Day : previousBrightnessMode);
+        applyBrightnessMode(isRacingMode ? BrightnessMode::Day : previousBrightnessMode);
+#endif
+      }
+    }
+    wasTouched = touched;
+
+    acquireSensorData();
+
+    if (!isRacingMode && currentGForce > 1.0F)
+    {
+      // 1Gを超えたらレーシングモードを開始
+      isRacingMode = true;
+      racingStartMs = now;
+      racingPrevMode = currentBrightnessMode;
+      applyBrightnessMode(BrightnessMode::Day);
+    }
+    else if (isRacingMode && now - racingStartMs >= RACING_MODE_DURATION_MS)
+    {
+      // 3分経過でレーシングモードを終了
+      isRacingMode = false;
+#if SENSOR_AMBIENT_LIGHT_PRESENT
+      updateBacklightLevel();
+#else
+      applyBrightnessMode(racingPrevMode);
 #endif
     }
-  }
-  wasTouched = touched;
 
-  acquireSensorData();
+    if (!isMenuVisible)
+    {
+      updateGauges();
+    }
 
-  if (!isRacingMode && currentGForce > 1.0F)
-  {
-    // 1Gを超えたらレーシングモードを開始
-    isRacingMode = true;
-    racingStartMs = now;
-    racingPrevMode = currentBrightnessMode;
-    applyBrightnessMode(BrightnessMode::Day);
-  }
-  else if (isRacingMode && now - racingStartMs >= RACING_MODE_DURATION_MS)
-  {
-    // 3分経過でレーシングモードを終了
-    isRacingMode = false;
-#if SENSOR_AMBIENT_LIGHT_PRESENT
-    updateBacklightLevel();
-#else
-    applyBrightnessMode(racingPrevMode);
-#endif
-  }
-
-  if (!isMenuVisible)
-  {
-    updateGauges();
-  }
-
-  fpsFrameCounter++;
-  if (now - lastFpsSecond >= FPS_INTERVAL_MS)
-  {
-    currentFps = fpsFrameCounter;
+    fpsFrameCounter++;
+    if (now - lastFpsSecond >= FPS_INTERVAL_MS)
+    {
+      currentFps = fpsFrameCounter;
 #if DEBUG_MODE_ENABLED
-    Serial.printf("FPS:%d\n", currentFps);
+      Serial.printf("FPS:%d\n", currentFps);
 #endif
-    fpsFrameCounter = 0;
-    lastFpsSecond = now;
-  }
+      fpsFrameCounter = 0;
+      lastFpsSecond = now;
+    }
 
 #if DEBUG_MODE_ENABLED
-  if (now - lastDebugPrint >= 1000UL)
-  {
-    // FPS更新とは別に1秒ごとにデータを出力
-    printSensorDebugInfo();
-    lastDebugPrint = now;
-  }
+    if (now - lastDebugPrint >= 1000UL)
+    {
+      // FPS更新とは別に1秒ごとにデータを出力
+      printSensorDebugInfo();
+      lastDebugPrint = now;
+    }
 #endif
+  }
+  catch (...)
+  {
+    // loop 内で例外が発生したらエラーを画面に表示して停止
+    Serial.println("[loop] 例外発生");
+    M5.Lcd.fillScreen(COLOR_BLACK);
+    M5.Lcd.setTextColor(COLOR_RED);
+    M5.Lcd.setTextSize(3);
+    M5.Lcd.setCursor(0, 0);
+    M5.Lcd.println("loop例外発生");
+    M5.Lcd.println("再起動してください");
+    while (true)
+    {
+      delay(1000);  // 無限待機で停止
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- display prominent red error message when `loop()` throws
- remove unused `resetSensorState()`

## Testing
- `clang-format -i src/modules/sensor.h src/modules/sensor.cpp src/main.cpp`
- `clang-tidy src/main.cpp src/modules/sensor.cpp --quiet` *(fails: missing headers and many warnings)*
- `act -j build` *(fails: command not found; package installation unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c57719dfe083229e3b3278ab2eba96