### PR TITLE
レーシングモード開始判定を0.1秒に短縮 / Shorten racing mode start delay to 0.1s

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,6 +1,5 @@
 #ifndef CONFIG_H
 #define CONFIG_H
-
 #include <cstdint>  // 整数型定義
 
 // ────────────────────── 設定 ──────────────────────

--- a/include/config.h
+++ b/include/config.h
@@ -3,8 +3,6 @@
 
 #include <cstdint>  // 整数型定義
 
-#include <cstdint>  // 整数型定義
-
 // ────────────────────── 設定 ──────────────────────
 // デバッグ用メッセージ表示の有無
 #define DEBUG_MODE_ENABLED 0
@@ -84,6 +82,9 @@ constexpr int MEDIAN_BUFFER_SIZE = 6;
 
 // レーシングモード継続時間 [ms]
 constexpr unsigned long RACING_MODE_DURATION_MS = 180000UL;
+
+// レーシングモード開始判定の継続時間 [ms]
+constexpr unsigned long RACING_MODE_START_DELAY_MS = 100UL;
 
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;


### PR DESCRIPTION
## Summary
- レーシングモード開始判定の継続時間を0.1秒に変更
- 1Gを0.1秒以上継続した場合のみレーシングモードへ移行
- メニュー表示やモード終了時に判定タイマーをリセット

## Testing
- `clang-format -i include/config.h src/main.cpp`
- `clang-tidy include/config.h src/main.cpp -- -Iinclude` *(コンパイルエラーにより失敗)*
- `act -j build` *(`act`コマンドが存在せず実行不可)*


------
https://chatgpt.com/codex/tasks/task_e_68c8180bd43c832293fbc504d99c3974