### PR TITLE
低油圧警告を解除後も3秒間表示 / Hold low pressure warning for 3 seconds after release

### DIFF
--- a/src/modules/low_warning.h
+++ b/src/modules/low_warning.h
@@ -9,7 +9,7 @@ extern const char *lastLowEventDir;  // Gの向き
 extern float lastLowEventDuration;   // 継続時間[s]
 extern float lastLowEventPressure;   // そのときの油圧[bar]
 
-// 低油圧警告表示。現在の表示状態とその変更の有無を返す
+// 低油圧警告表示。解除後も3秒間表示を継続し、現在の表示状態とその変更の有無を返す
 bool drawLowPressureWarning(M5Canvas &canvas, float gForce, float pressure, bool &stateChanged);
 
 #endif  // LOW_WARNING_H


### PR DESCRIPTION
## Summary
- JP: イベント記録用フラグを追加して状態管理を見直し、警告表示を毎フレーム再描画するようにしました
- EN: Added an event-logged flag to refine state management and redraw the warning every frame

## Testing
- `clang-format -i src/modules/low_warning.cpp src/modules/low_warning.h`
- `clang-tidy src/modules/low_warning.cpp -- -Iinclude` *(failed: 'M5GFX.h' file not found and warnings as errors)*
- `act -j build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81532d82c83228e302bc36472d3dc