### PR TITLE
レーシングモード制御のモジュール化 / Modularize racing mode control

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -3,8 +3,6 @@
 
 #include <cstdint>  // 整数型定義
 
-#include <cstdint>  // 整数型定義
-
 // ────────────────────── 設定 ──────────────────────
 // デバッグ用メッセージ表示の有無
 #define DEBUG_MODE_ENABLED 0
@@ -84,6 +82,9 @@ constexpr int MEDIAN_BUFFER_SIZE = 6;
 
 // レーシングモード継続時間 [ms]
 constexpr unsigned long RACING_MODE_DURATION_MS = 180000UL;
+
+// レーシングモード開始判定の継続時間 [ms]
+constexpr unsigned long RACING_MODE_START_DELAY_MS = 100UL;
 
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;

--- a/src/modules/racing_indicator.cpp
+++ b/src/modules/racing_indicator.cpp
@@ -1,8 +1,5 @@
 #include "racing_indicator.h"
 
-// レーシングモードかどうかを保持
-bool isRacingMode = false;
-
 // Rマークが描画済みかどうか
 static bool indicatorDrawn = false;
 

--- a/src/modules/racing_mode.cpp
+++ b/src/modules/racing_mode.cpp
@@ -1,0 +1,84 @@
+#include "racing_mode.h"
+
+#include "backlight.h"
+#include "racing_indicator.h"
+#include "sensor.h"
+
+// レーシングモードかどうかを保持
+bool isRacingMode = false;
+// レーシング開始時刻
+static unsigned long racingStartMs = 0;
+// レーシング開始前の輝度モード
+static BrightnessMode racingPrevMode = BrightnessMode::Day;
+// レーシング判定開始時刻
+static unsigned long racingJudgeStartMs = 0;
+
+// レーシングモード開始前の輝度モードを取得
+BrightnessMode getRacingModePrevBrightness() { return racingPrevMode; }
+
+// レーシングモード関連の状態を初期化
+void resetRacingModeState()
+{
+  isRacingMode = false;
+  racingStartMs = 0;
+  racingJudgeStartMs = 0;
+}
+
+// レーシングモードの開始・終了判定を更新
+void updateRacingModeState(unsigned long now)
+{
+  if (isRacingMode && currentGForce > 1.0F)
+  {
+    // レーシングモード中に1Gを超えたら経過タイマーをリセット
+    racingStartMs = now;
+    return;
+  }
+
+  if (isRacingMode)
+  {
+    const unsigned long elapsedMs = now - racingStartMs;  // unsigned long の減算でオーバーフローを吸収
+    if (elapsedMs < RACING_MODE_DURATION_MS)
+    {
+      // 継続時間内であればレーシングモードを維持
+      return;
+    }
+
+    // 一定時間経過でレーシングモードを終了
+    isRacingMode = false;
+#if SENSOR_AMBIENT_LIGHT_PRESENT
+    updateBacklightLevel();
+#else
+    applyBrightnessMode(racingPrevMode);
+#endif
+    racingJudgeStartMs = 0;  // 判定タイマーをリセット
+    return;
+  }
+
+  if (currentGForce <= 1.0F)
+  {
+    // 1G未満に戻ったら判定タイマーを破棄
+    racingJudgeStartMs = 0;
+    return;
+  }
+
+  if (racingJudgeStartMs == 0)
+  {
+    // 判定開始の初回だけタイマーをセット
+    racingJudgeStartMs = now;
+    return;
+  }
+
+  const unsigned long elapsedMs = now - racingJudgeStartMs;  // unsigned long 同士の減算はオーバーフローしても安全
+  if (elapsedMs < RACING_MODE_START_DELAY_MS)
+  {
+    // 所定時間に満たない間は様子を見る
+    return;
+  }
+
+  // 1G を所定時間継続したのでレーシングモードを開始
+  isRacingMode = true;
+  racingStartMs = now;
+  racingPrevMode = currentBrightnessMode;
+  racingJudgeStartMs = 0;
+  applyBrightnessMode(BrightnessMode::Day);
+}

--- a/src/modules/racing_mode.h
+++ b/src/modules/racing_mode.h
@@ -1,0 +1,13 @@
+#ifndef RACING_MODE_H
+#define RACING_MODE_H
+
+#include "config.h"
+
+// レーシングモード開始前の輝度モードを取得
+BrightnessMode getRacingModePrevBrightness();
+// レーシングモード関連の状態を初期化
+void resetRacingModeState();
+// レーシングモードの開始・終了判定を更新
+void updateRacingModeState(unsigned long now);
+
+#endif  // RACING_MODE_H


### PR DESCRIPTION
## Summary
- レーシングモードの状態管理を新しい `racing_mode` モジュールに分離し、開始・終了ロジックを整理しました / Separated racing mode state management into a new `racing_mode` module and streamlined the start/stop logic.
- メインループを新モジュールのAPIで更新し、メニュー表示時のリセット処理を整理しました / Updated the main loop to rely on the new module APIs and tidy up reset handling when showing the menu.

## Testing
- `clang-format -i src/main.cpp src/modules/racing_indicator.cpp src/modules/racing_mode.cpp src/modules/racing_mode.h`
- `clang-tidy src/main.cpp src/modules/racing_mode.cpp src/modules/racing_indicator.cpp -- -Iinclude` *(M5CoreS3.h などのヘッダーが見つからず失敗 / failed because headers such as M5CoreS3.h are missing)*
- `act -j build` *(`act` コマンドが存在せず失敗 / failed because the `act` command is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c8180bd43c832293fbc504d99c3974