### PR TITLE
指示ガイドラインを再構成 / Reorganize contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,34 @@
-#Coding Guidelines
+# Coding Guidelines / コーディングガイドライン
 
-- ブランチ名は英語のみを使用してください。/ Use English only for branch names.
-  - 不具合修正: `fix/` プレフィックスを使用 / For bug fixes, use the `fix/` prefix.
-  - リファクタ: `react/` プレフィックスを使用 / For refactoring, use the `react/` prefix.
-- プルリクエストのタイトルと概要は、日本語と英語の二言語で記述してください。/ Provide PR titles and descriptions in both Japanese and English.
+このリポジトリで作業する際は、以下のルールに従ってください。
+
+## ブランチ運用 / Branch Workflow
+- ブランチ名は必ず英語で作成してください。/ Always name branches in English.
+- 作業内容に応じて、次のプレフィックスを使用してください。/ Choose the branch prefix that matches your task.
+
+| 作業種別 / Work Type | ブランチプレフィックス / Branch Prefix |
+| --- | --- |
+| 不具合修正 / Bug Fix | `fix/` |
+| リファクタリング / Refactor | `react/` |
+
+## プルリクエスト / Pull Requests
+- タイトルと概要は日本語と英語の二言語で記載してください。/ Provide PR titles and summaries in both Japanese and English.
+
+## コード記述 / Code Authoring
 - コード中のコメントは日本語で記述してください。/ Write code comments in Japanese.
-- PRレビューやレビューコメントは日本語で返してください。/ Provide PR reviews and review comments in Japanese.
-- Copilot のレビューコメントは日本語で行い、以下の重要度区分を使用してください。/ Write Copilot review comments in Japanese and use the following importance levels.
-  - [MUST]: 不具合やメンテコストを意識すると修正が必須 / Fix is mandatory when considering bugs or maintenance costs.
-  - [IMO] ★☆☆: できれば修正したい内容を☆の数で表現する / Prefer to fix; mark with ★★☆(ex.)
-  - [NITS]: 細かい指摘で、サジェストを承認すればすぐ修正できる形式にしてください。/ Minor suggestions that should be provided in an easily applicable suggestion format.
-- コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
-- 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.
-- コードを変更したら `act -j build` を実行してCIを確認し、プッシュ後は GitHub Actions の終了を待ち、エラーがあれば修正して再度プッシュしてください。/ After modifying code, run `act -j build` to check CI locally. After pushing, wait for GitHub Actions to finish and push again if errors occur.
+
+## レビュー / Reviews
+- PRレビューとレビューコメントは日本語で返してください。/ Provide PR reviews and review comments in Japanese.
+- Copilotレビューコメントは日本語で記載し、以下の重要度区分を使用してください。/ Write Copilot review comments in Japanese using the following severity levels.
+
+| ラベル / Label | 説明 / Description |
+| --- | --- |
+| `[MUST]` | 不具合やメンテナンスコストを考慮して必ず修正すべき内容。/ Mandatory fixes considering bugs or maintenance costs. |
+| `[IMO]` + ★☆☆〜★★★ | 修正が望ましい内容を★の数で重要度表現。/ Preferred fixes with star ratings to indicate importance. |
+| `[NITS]` | サジェストで即適用できる細かな指摘。/ Minor suggestions that should be provided in an easily applicable format. |
+
+## ツールとワークフロー / Tooling & Workflow
+- コミット前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
+- 2回目以降の作業では、`git pull && git merge main` を実行して競合を解消してください。/ When resuming work, run `git pull && git merge main` to resolve conflicts.
+- コード変更後は `act -j build` を実行してローカルでCIを確認してください。/ After modifying code, run `act -j build` to check CI locally.
+- プッシュ後はGitHub Actionsの完了を待ち、エラーがあれば修正して再度プッシュしてください。/ After pushing, wait for GitHub Actions to finish and push again if any errors occur.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,15 +1,32 @@
-#Coding Guidelines
+# Copilot Review Guidelines / Copilotレビューガイドライン
 
-- ブランチ名は英語のみを使用してください。/ Use English only for branch names.
-  - 不具合修正: `fix/` プレフィックスを使用 / For bug fixes, use the `fix/` prefix.
-  - リファクタ: `react/` プレフィックスを使用 / For refactoring, use the `react/` prefix.
-- プルリクエストのタイトルと概要は、日本語と英語の二言語で記述してください。/ Provide PR titles and descriptions in both Japanese and English.
-- コード中のコメントは日本語で記述してください。/ Write code comments in Japanese.
-- PRレビューやレビューコメントは日本語で返してください。/ Provide PR reviews and review comments in Japanese.
-- Copilot のレビューコメントは日本語で行い、以下の重要度区分を使用してください。/ Write Copilot review comments in Japanese and use the following importance levels.
-  - [MUST]: 不具合やメンテコストを意識すると修正が必須 / Fix is mandatory when considering bugs or maintenance costs.
-  - [IMO] ★☆☆: できれば修正したい内容を☆の数で表現する / Prefer to fix; mark with ★★☆(ex.)
-  - [NITS]: 細かい指摘で、サジェストを承認すればすぐ修正できる形式にしてください。/ Minor suggestions that should be provided in an easily applicable suggestion format.
-- コミットする前に `.clang-format` と `.clang-tidy` を実行してください。/ Run `.clang-format` and `.clang-tidy` before committing.
-- 二回目以降のコード作成を行う場合、`git pull && git merge main` を実行して競合を解決してください。/ When working on code again, run `git pull && git merge main` to resolve conflicts.
-- コードを変更したら `act -j build` を実行してCIを確認し、プッシュ後は GitHub Actions の終了を待ち、エラーがあれば修正して再度プッシュしてください。/ After modifying code, run `act -j build` to check CI locally. After pushing, wait for GitHub Actions to finish and push again if errors occur.
+Copilotでレビューを行う際は、次の指針を必ず確認してください。
+
+## ブランチとPRの基本 / Branch & PR Basics
+- ブランチ名は英語のみを使用し、作業内容に応じて指定のプレフィックスを選んでください。/ Use only English branch names and apply the appropriate prefix.
+
+| 作業種別 / Work Type | ブランチプレフィックス / Branch Prefix |
+| --- | --- |
+| 不具合修正 / Bug Fix | `fix/` |
+| リファクタリング / Refactor | `react/` |
+
+- プルリクエストのタイトルと概要は、日本語と英語の二言語で記載されているか確認してください。/ Ensure PR titles and summaries are provided in both Japanese and English.
+
+## コメントスタイル / Comment Style
+- レビューコメントはすべて日本語で記載してください。/ Write every review comment in Japanese.
+- コードコメントも日本語で統一されているかを確認し、必要に応じて指摘してください。/ Check that code comments remain in Japanese and point out deviations.
+
+## 重要度ラベル / Importance Labels
+- 指摘には以下のラベルを使用し、必要に応じてスター数で重要度を示してください。/ Apply the following labels to feedback, using star ratings when appropriate.
+
+| ラベル / Label | 説明 / Description |
+| --- | --- |
+| `[MUST]` | 不具合やメンテコストを意識すると修正が必須な項目。/ Mandatory fixes due to bugs or maintenance costs. |
+| `[IMO]` + ★☆☆〜★★★ | 修正が望ましい内容を星の数で重要度表現。/ Preferred fixes, with stars indicating priority. |
+| `[NITS]` | サジェストを承認すればすぐ修正できる細かな指摘。/ Minor suggestions that should be provided in an easily applicable format. |
+
+## ツールとワークフローの確認 / Tooling & Workflow Checks
+- コミット前に `.clang-format` と `.clang-tidy` が実行されているか確認してください。/ Confirm `.clang-format` and `.clang-tidy` have been run before committing.
+- 追加作業時は `git pull && git merge main` による最新化が行われているか注目してください。/ Ensure contributors refresh their branches with `git pull && git merge main` when resuming work.
+- コード変更後に `act -j build` を実行し、CIの結果に問題がないか確認するよう促してください。/ Encourage running `act -j build` after modifications to verify CI results.
+- プッシュ後はGitHub Actionsの完了を待ち、エラー対応が行われているか確認してください。/ Verify that contributors wait for GitHub Actions to finish and address any errors after pushing.


### PR DESCRIPTION
## 概要 / Summary
- AGENTS.mdをセクション分けと表記の二言語化で整理し、遵守すべき手順をカテゴリごとに明確化しました。
- Copilot向け指示ファイルをレビュー視点ごとに再構成し、重要度ラベルやワークフロー確認項目を表形式で提示しました。

## テスト / Tests
- clang-format -n --Werror $(git ls-files '*.cpp' '*.h' '*.hpp')
- clang-tidy src/main.cpp -- -std=c++17
- act -j build


------
https://chatgpt.com/codex/tasks/task_e_68d0df6be4208322b8ef757e6073acde