### PR TITLE
fix: レーシングモード復帰時に輝度取得を行わない / Avoid backlight refresh on racing mode exit

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -3,8 +3,6 @@
 
 #include <cstdint>  // 整数型定義
 
-#include <cstdint>  // 整数型定義
-
 // ────────────────────── 設定 ──────────────────────
 // デバッグ用メッセージ表示の有無
 #define DEBUG_MODE_ENABLED 0
@@ -84,6 +82,10 @@ constexpr int MEDIAN_BUFFER_SIZE = 6;
 
 // レーシングモード継続時間 [ms]
 constexpr unsigned long RACING_MODE_DURATION_MS = 180000UL;
+// レーシングモード開始判定の閾値 [G]
+constexpr float RACING_MODE_START_THRESHOLD_G = 1.0f;
+// レーシングモード開始判定で閾値超過が必要な継続時間 [ms]
+constexpr unsigned long RACING_MODE_START_HOLD_MS = 100UL;
 
 // FPS 更新間隔 [ms]
 constexpr unsigned long FPS_INTERVAL_MS = 1000UL;

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,3 +37,10 @@ lib_deps =
 lib_ldf_mode = deep
 monitor_speed = 115200
 test_filter = ci_dummy
+
+[env:native]
+platform = native
+test_filter = racing_mode
+test_build_src = false
+build_flags =
+  -std=gnu++17

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,11 +13,10 @@
 unsigned long lastFpsSecond = 0;  // 直近1秒判定用
 int fpsFrameCounter = 0;
 int currentFps = 0;
-unsigned long lastDebugPrint = 0;                                    // デバッグ表示用タイマー
-unsigned long lastFrameTimeUs = 0;                                   // 前回フレーム開始時刻
-bool isMenuVisible = false;                                          // メニュー表示中かどうか
-static bool wasTouched = false;                                      // 前回タッチされていたか
-static BrightnessMode previousBrightnessMode = BrightnessMode::Day;  // メニュー前の輝度モード
+unsigned long lastDebugPrint = 0;   // デバッグ表示用タイマー
+unsigned long lastFrameTimeUs = 0;  // 前回フレーム開始時刻
+bool isMenuVisible = false;         // メニュー表示中かどうか
+static bool wasTouched = false;     // 前回タッチされていたか
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -133,9 +132,7 @@ void loop()
     isMenuVisible = !isMenuVisible;
     if (isMenuVisible)
     {
-      previousBrightnessMode =
-          isRacingMode ? getRacingPrevBrightnessMode() : currentBrightnessMode;  // 現在の輝度モードを保存
-      forceStopRacingMode();                                                     // 詳細画面ではレーシングモードを解除
+      forceStopRacingMode();  // 詳細画面ではレーシングモードを解除
       drawMenuScreen();
       // メニュー表示中は輝度を最大にする
       applyBrightnessMode(BrightnessMode::Day);
@@ -154,7 +151,7 @@ void loop()
         updateBacklightLevel();
       }
 #else
-      applyBrightnessMode(isRacingMode ? BrightnessMode::Day : previousBrightnessMode);
+      applyBrightnessMode(getRacingPrevBrightnessMode());
 #endif
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "modules/backlight.h"
 #include "modules/display.h"
 #include "modules/racing_indicator.h"
+#include "modules/racing_mode.h"
 #include "modules/sensor.h"
 
 // ── FPS 計測用 ──
@@ -17,8 +18,6 @@ unsigned long lastFrameTimeUs = 0;                                   // 前回�
 bool isMenuVisible = false;                                          // メニュー表示中かどうか
 static bool wasTouched = false;                                      // 前回タッチされていたか
 static BrightnessMode previousBrightnessMode = BrightnessMode::Day;  // メニュー前の輝度モード
-static unsigned long racingStartMs = 0;                              // レーシング開始時刻
-static BrightnessMode racingPrevMode = BrightnessMode::Day;          // レーシング開始前の輝度
 
 // ────────────────────── デバッグ情報表示 ──────────────────────
 static void printSensorDebugInfo()
@@ -134,9 +133,9 @@ void loop()
     isMenuVisible = !isMenuVisible;
     if (isMenuVisible)
     {
-      previousBrightnessMode = isRacingMode ? racingPrevMode : currentBrightnessMode;  // 現在の輝度モードを保存
-      isRacingMode = false;                                                            // 詳細画面ではレーシングモードを解除
-      racingStartMs = 0;  // レーシングモードのタイマーをリセット
+      previousBrightnessMode =
+          isRacingMode ? getRacingPrevBrightnessMode() : currentBrightnessMode;  // 現在の輝度モードを保存
+      forceStopRacingMode();                                                     // 詳細画面ではレーシングモードを解除
       drawMenuScreen();
       // メニュー表示中は輝度を最大にする
       applyBrightnessMode(BrightnessMode::Day);
@@ -163,24 +162,7 @@ void loop()
 
   acquireSensorData();
 
-  if (!isRacingMode && currentGForce > 1.0F)
-  {
-    // 1Gを超えたらレーシングモードを開始
-    isRacingMode = true;
-    racingStartMs = now;
-    racingPrevMode = currentBrightnessMode;
-    applyBrightnessMode(BrightnessMode::Day);
-  }
-  else if (isRacingMode && now - racingStartMs >= RACING_MODE_DURATION_MS)
-  {
-    // 3分経過でレーシングモードを終了
-    isRacingMode = false;
-#if SENSOR_AMBIENT_LIGHT_PRESENT
-    updateBacklightLevel();
-#else
-    applyBrightnessMode(racingPrevMode);
-#endif
-  }
+  updateRacingMode(now, currentGForce);
 
   if (!isMenuVisible)
   {

--- a/src/modules/racing_mode.cpp
+++ b/src/modules/racing_mode.cpp
@@ -64,6 +64,11 @@ void updateRacingMode(unsigned long nowMs, float gForce)  // NOLINT(bugprone-eas
 
 void forceStopRacingMode()
 {
+  bool wasRacing = isRacingMode;  // 呼び出し直前の状態を保持
+  if (!wasRacing)
+  {
+    racingPrevMode = currentBrightnessMode;  // レーシングモード外では現在の輝度を保存
+  }
   isRacingMode = false;
   racingStartMs = 0;
   isGForceHoldActive = false;

--- a/src/modules/racing_mode.cpp
+++ b/src/modules/racing_mode.cpp
@@ -1,0 +1,82 @@
+#include "racing_mode.h"
+
+#include "backlight.h"
+#include "racing_indicator.h"
+
+// レーシングモードの内部状態
+static bool isGForceHoldActive = false;                      // 閾値超過状態が継続中か
+static unsigned long gForceAboveThresholdSince = 0;          // 閾値を超えた時刻
+static unsigned long racingStartMs = 0;                      // レーシングモード開始時刻
+static BrightnessMode racingPrevMode = BrightnessMode::Day;  // レーシング開始前の輝度
+
+// レーシングモードを開始する
+static void startRacingMode(unsigned long nowMs)
+{
+  isRacingMode = true;
+  isGForceHoldActive = false;
+  gForceAboveThresholdSince = 0;
+  racingStartMs = nowMs;
+  racingPrevMode = currentBrightnessMode;
+  applyBrightnessMode(BrightnessMode::Day);
+}
+
+// レーシングモードを終了し、輝度を元に戻す
+static void finishRacingMode()
+{
+  isRacingMode = false;
+  racingStartMs = 0;
+  isGForceHoldActive = false;
+  gForceAboveThresholdSince = 0;
+  applyBrightnessMode(racingPrevMode);
+}
+
+void updateRacingMode(unsigned long nowMs, float gForce)  // NOLINT(bugprone-easily-swappable-parameters)
+{
+  if (isRacingMode)
+  {
+    if (racingStartMs != 0 && nowMs - racingStartMs >= RACING_MODE_DURATION_MS)
+    {
+      finishRacingMode();
+    }
+    return;
+  }
+
+  if (gForce >= RACING_MODE_START_THRESHOLD_G)
+  {
+    if (!isGForceHoldActive)
+    {
+      isGForceHoldActive = true;
+      gForceAboveThresholdSince = nowMs;
+    }
+    else if (nowMs - gForceAboveThresholdSince >= RACING_MODE_START_HOLD_MS)
+    {
+      isGForceHoldActive = false;
+      gForceAboveThresholdSince = 0;
+      startRacingMode(nowMs);
+    }
+  }
+  else
+  {
+    isGForceHoldActive = false;
+    gForceAboveThresholdSince = 0;
+  }
+}
+
+void forceStopRacingMode()
+{
+  isRacingMode = false;
+  racingStartMs = 0;
+  isGForceHoldActive = false;
+  gForceAboveThresholdSince = 0;
+}
+
+auto getRacingPrevBrightnessMode() -> BrightnessMode { return racingPrevMode; }
+
+void resetRacingModeState()
+{
+  isRacingMode = false;
+  isGForceHoldActive = false;
+  gForceAboveThresholdSince = 0;
+  racingStartMs = 0;
+  racingPrevMode = BrightnessMode::Day;
+}

--- a/src/modules/racing_mode.h
+++ b/src/modules/racing_mode.h
@@ -1,0 +1,18 @@
+#ifndef RACING_MODE_H
+#define RACING_MODE_H
+
+#include "config.h"
+
+// レーシングモードの状態更新を行う
+void updateRacingMode(unsigned long nowMs, float gForce);
+
+// レーシングモードを強制的に停止し、判定状態を初期化する
+void forceStopRacingMode();
+
+// レーシングモード開始前の輝度モードを取得する
+BrightnessMode getRacingPrevBrightnessMode();
+
+// レーシングモードの内部状態を初期化する
+void resetRacingModeState();
+
+#endif  // RACING_MODE_H

--- a/test/racing_mode/test_racing_mode.cpp
+++ b/test/racing_mode/test_racing_mode.cpp
@@ -112,6 +112,17 @@ void test_force_stop_does_not_restore_brightness()
   TEST_ASSERT_EQUAL(BrightnessMode::Day, currentBrightnessMode);
 }
 
+// レーシングモード外での強制停止時に現在の輝度を保持することを確認
+void test_force_stop_updates_prev_mode_when_not_racing()
+{
+  currentBrightnessMode = BrightnessMode::Dusk;
+
+  forceStopRacingMode();
+
+  TEST_ASSERT_EQUAL(BrightnessMode::Dusk, getRacingPrevBrightnessMode());
+  TEST_ASSERT_FALSE(isRacingMode);
+}
+
 // 規定時間経過で自動的に輝度が復帰することを確認
 void test_racing_mode_auto_finish_restores_brightness()
 {
@@ -136,6 +147,7 @@ void setup()
   RUN_TEST(test_racing_mode_starts_when_g_equals_threshold);
   RUN_TEST(test_racing_mode_resets_hold_when_g_drops);
   RUN_TEST(test_force_stop_does_not_restore_brightness);
+  RUN_TEST(test_force_stop_updates_prev_mode_when_not_racing);
   RUN_TEST(test_racing_mode_auto_finish_restores_brightness);
   UNITY_END();
 }

--- a/test/racing_mode/test_racing_mode.cpp
+++ b/test/racing_mode/test_racing_mode.cpp
@@ -1,0 +1,146 @@
+#include <unity.h>
+
+#include "../../include/config.h"
+
+// ────────────────────── テスト用スタブ ──────────────────────
+bool isRacingMode = false;
+BrightnessMode currentBrightnessMode = BrightnessMode::Day;
+int latestLux = 0;
+int medianLuxValue = 0;
+
+static int applyBrightnessCallCount = 0;
+static int backlightUpdateCallCount = 0;
+
+void applyBrightnessMode(BrightnessMode mode)
+{
+  currentBrightnessMode = mode;
+  ++applyBrightnessCallCount;
+}
+
+void updateBacklightLevel()
+{
+  currentBrightnessMode = BrightnessMode::Night;
+  ++backlightUpdateCallCount;
+}
+
+#include "../../src/modules/racing_mode.cpp"
+
+static void resetTestState()
+{
+  resetRacingModeState();
+  isRacingMode = false;
+  currentBrightnessMode = BrightnessMode::Night;
+  applyBrightnessCallCount = 0;
+  backlightUpdateCallCount = 0;
+}
+
+void setUp() { resetTestState(); }
+
+void tearDown()
+{
+  // テスト終了時の処理は不要
+}
+
+// 0.1秒間の連続超過が必要であることを確認
+void test_racing_mode_requires_hold()
+{
+  updateRacingMode(0UL, 1.2F);
+  TEST_ASSERT_FALSE(isRacingMode);
+
+  updateRacingMode(RACING_MODE_START_HOLD_MS - 1, 1.2F);
+  TEST_ASSERT_FALSE(isRacingMode);
+  TEST_ASSERT_EQUAL(0, applyBrightnessCallCount);
+
+  updateRacingMode(RACING_MODE_START_HOLD_MS, 1.2F);
+  TEST_ASSERT_TRUE(isRacingMode);
+  TEST_ASSERT_EQUAL(BrightnessMode::Day, currentBrightnessMode);
+  TEST_ASSERT_EQUAL(BrightnessMode::Night, getRacingPrevBrightnessMode());
+  TEST_ASSERT_EQUAL(1, applyBrightnessCallCount);
+}
+
+// 起動直後であっても閾値超過から指定時間経過すれば起動することを確認
+void test_racing_mode_starts_after_initial_hold()
+{
+  updateRacingMode(0UL, 1.2F);
+  TEST_ASSERT_FALSE(isRacingMode);
+
+  updateRacingMode(RACING_MODE_START_HOLD_MS, 1.2F);
+  TEST_ASSERT_TRUE(isRacingMode);
+  TEST_ASSERT_EQUAL(BrightnessMode::Day, currentBrightnessMode);
+  TEST_ASSERT_EQUAL(BrightnessMode::Night, getRacingPrevBrightnessMode());
+  TEST_ASSERT_EQUAL(1, applyBrightnessCallCount);
+}
+
+// 閾値と同じGでも保持時間経過で起動することを確認
+void test_racing_mode_starts_when_g_equals_threshold()
+{
+  updateRacingMode(0UL, RACING_MODE_START_THRESHOLD_G);
+  TEST_ASSERT_FALSE(isRacingMode);
+
+  updateRacingMode(RACING_MODE_START_HOLD_MS, RACING_MODE_START_THRESHOLD_G);
+  TEST_ASSERT_TRUE(isRacingMode);
+  TEST_ASSERT_EQUAL(BrightnessMode::Day, currentBrightnessMode);
+  TEST_ASSERT_EQUAL(BrightnessMode::Night, getRacingPrevBrightnessMode());
+  TEST_ASSERT_EQUAL(1, applyBrightnessCallCount);
+}
+
+// 閾値未満に戻ると保持時間がリセットされることを確認
+void test_racing_mode_resets_hold_when_g_drops()
+{
+  unsigned long halfHold = RACING_MODE_START_HOLD_MS / 2;
+  updateRacingMode(0UL, 1.2F);
+  updateRacingMode(halfHold, 0.5F);
+  updateRacingMode(RACING_MODE_START_HOLD_MS, 1.2F);
+  TEST_ASSERT_FALSE(isRacingMode);
+
+  updateRacingMode(RACING_MODE_START_HOLD_MS + RACING_MODE_START_HOLD_MS, 1.2F);
+  TEST_ASSERT_TRUE(isRacingMode);
+  TEST_ASSERT_EQUAL(1, applyBrightnessCallCount);
+}
+
+// 強制停止時は輝度復帰を行わないことを確認
+void test_force_stop_does_not_restore_brightness()
+{
+  updateRacingMode(0UL, 1.2F);
+  updateRacingMode(RACING_MODE_START_HOLD_MS, 1.2F);
+  TEST_ASSERT_TRUE(isRacingMode);
+  TEST_ASSERT_EQUAL(BrightnessMode::Day, currentBrightnessMode);
+
+  forceStopRacingMode();
+  TEST_ASSERT_FALSE(isRacingMode);
+  TEST_ASSERT_EQUAL(0, backlightUpdateCallCount);
+  TEST_ASSERT_EQUAL(BrightnessMode::Day, currentBrightnessMode);
+}
+
+// 規定時間経過で自動的に輝度が復帰することを確認
+void test_racing_mode_auto_finish_restores_brightness()
+{
+  updateRacingMode(0UL, 1.2F);
+  updateRacingMode(RACING_MODE_START_HOLD_MS, 1.2F);
+  TEST_ASSERT_TRUE(isRacingMode);
+
+  unsigned long finishTime = RACING_MODE_START_HOLD_MS + RACING_MODE_DURATION_MS + 1UL;
+  updateRacingMode(finishTime, 0.0F);
+
+  TEST_ASSERT_FALSE(isRacingMode);
+  TEST_ASSERT_EQUAL(0, backlightUpdateCallCount);
+  TEST_ASSERT_EQUAL(2, applyBrightnessCallCount);
+  TEST_ASSERT_EQUAL(BrightnessMode::Night, currentBrightnessMode);
+}
+
+void setup()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_racing_mode_requires_hold);
+  RUN_TEST(test_racing_mode_starts_after_initial_hold);
+  RUN_TEST(test_racing_mode_starts_when_g_equals_threshold);
+  RUN_TEST(test_racing_mode_resets_hold_when_g_drops);
+  RUN_TEST(test_force_stop_does_not_restore_brightness);
+  RUN_TEST(test_racing_mode_auto_finish_restores_brightness);
+  UNITY_END();
+}
+
+void loop()
+{
+  // ループ処理は不要
+}


### PR DESCRIPTION
## 概要 / Summary
- (JP) レーシングモード終了処理で保存済みの輝度モードへ復帰するようにし、ALSによる再取得を行わないよう修正しました。
- (EN) Updated the racing mode shutdown logic to restore the stored brightness mode without triggering an ALS refresh.
- (JP) 自動終了を検証するUnityテストを更新し、輝度取得が走らず保存済みのモードへ戻ることを確認できるようにしました。
- (EN) Adjusted the Unity test for auto-finish to ensure no backlight update runs and the stored mode is restored.

## テスト / Tests
- clang-format -i src/modules/racing_mode.cpp test/racing_mode/test_racing_mode.cpp
- clang-tidy src/modules/racing_mode.cpp -- -std=gnu++17 -Iinclude -Isrc *(missing M5 headers)*
- ~/.local/bin/platformio test -e native -vvv *(command not found)*
- act -j build *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d01bac69988322aba8abc08c1c67e9