### PR TITLE
clang-tidy 実行向けスタブ追加 / Add stubs for clang-tidy execution

### DIFF
--- a/stubs/Adafruit_ADS1X15.h
+++ b/stubs/Adafruit_ADS1X15.h
@@ -1,0 +1,17 @@
+#ifndef STUBS_ADAFRUIT_ADS1X15_H
+#define STUBS_ADAFRUIT_ADS1X15_H
+
+#include <cstdint>
+
+// ────────────────────── ADS1015 スタブ ──────────────────────
+constexpr int RATE_ADS1015_1600SPS = 0;
+
+class Adafruit_ADS1015
+{
+public:
+  bool begin() { return true; }
+  void setDataRate(int) {}
+  auto readADC_SingleEnded(uint8_t) -> int16_t { return 0; }
+};
+
+#endif  // STUBS_ADAFRUIT_ADS1X15_H

--- a/stubs/Arduino.h
+++ b/stubs/Arduino.h
@@ -1,0 +1,31 @@
+#ifndef STUBS_ARDUINO_H
+#define STUBS_ARDUINO_H
+
+#include <cstdint>
+
+// ────────────────────── Arduino 互換スタブ ──────────────────────
+inline void delay(unsigned long) {}
+inline void delayMicroseconds(unsigned int) {}
+inline auto millis() -> unsigned long { return 0; }
+inline auto micros() -> unsigned long { return 0; }
+inline auto radians(float deg) -> float { return deg * 3.14159265358979323846F / 180.0F; }
+
+constexpr int INPUT_PULLUP = 0;
+
+inline void pinMode(int, int) {}
+
+class HardwareSerial
+{
+public:
+  void begin(unsigned long) {}
+  void println(const char *) {}
+  void printf(const char *, ...) {}
+  void setTextSize(int) {}
+  void setTextColor(uint16_t) {}
+  void setCursor(int, int) {}
+};
+
+// デバッグ出力用シリアルのスタブ
+inline HardwareSerial Serial;
+
+#endif  // STUBS_ARDUINO_H

--- a/stubs/M5CoreS3.h
+++ b/stubs/M5CoreS3.h
@@ -1,0 +1,97 @@
+#ifndef STUBS_M5CORES3_H
+#define STUBS_M5CORES3_H
+
+#include "Arduino.h"
+#include "M5GFX.h"
+#include "WiFi.h"
+
+// ────────────────────── LTR-553 関連スタブ ──────────────────────
+struct Ltr5xx_Init_Basic_Para
+{
+  int ps_led_pulse_freq = 0;
+  int als_gain = 0;
+  int als_integration_time = 0;
+};
+
+constexpr Ltr5xx_Init_Basic_Para LTR5XX_BASE_PARA_CONFIG_DEFAULT = {};
+constexpr int LTR5XX_LED_PULSE_FREQ_40KHZ = 0;
+constexpr int LTR5XX_ALS_GAIN_1X = 0;
+constexpr int LTR5XX_ALS_INTEGRATION_TIME_100MS = 0;
+constexpr int LTR5XX_ALS_ACTIVE_MODE = 0;
+
+class Ltr553Class
+{
+public:
+  void begin(Ltr5xx_Init_Basic_Para *) {}
+  void setAlsMode(int) {}
+  auto getAlsValue() const -> int { return 0; }
+};
+
+// ────────────────────── CoreS3 本体スタブ ──────────────────────
+class CoreS3Class
+{
+public:
+  void begin(int) {}
+  Ltr553Class Ltr553;
+};
+
+inline CoreS3Class CoreS3;
+
+// ────────────────────── M5CoreS3 メインクラス ──────────────────────
+class M5Power
+{
+public:
+  void begin() {}
+  void setExtOutput(bool) {}
+  void setLed(int) {}
+  void setUsbOutput(bool) {}
+  void setBatteryCharge(bool) {}
+};
+
+class M5Lcd
+{
+public:
+  void clear() {}
+  void fillScreen(uint16_t) {}
+  void setTextSize(int) {}
+  void setTextColor(uint16_t) {}
+  void setCursor(int, int) {}
+  void println(const char *) {}
+};
+
+class M5Imu
+{
+public:
+  void begin() {}
+  void getAccelData(float *x, float *y, float *z)
+  {
+    if (x) *x = 0.0F;
+    if (y) *y = 0.0F;
+    if (z) *z = 0.0F;
+  }
+};
+
+class M5Touch
+{
+public:
+  auto getCount() const -> int { return 0; }
+};
+
+class M5Class
+{
+public:
+  void begin() {}
+  auto config() const -> int { return 0; }
+  void update() {}
+
+  M5Power Power;
+  M5Lcd Lcd;
+  M5Imu Imu;
+  M5Touch Touch;
+};
+
+inline M5Class M5;
+
+inline void btStop() {}
+
+#endif  // STUBS_M5CORES3_H

--- a/stubs/M5GFX.h
+++ b/stubs/M5GFX.h
@@ -1,0 +1,75 @@
+#ifndef STUBS_M5GFX_H
+#define STUBS_M5GFX_H
+
+#include "Arduino.h"
+
+// ────────────────────── フォントスタブ ──────────────────────
+namespace fonts
+{
+struct FontStub
+{
+};
+
+inline FontStub Font0;
+inline FontStub FreeSansBold12pt7b;
+}  // namespace fonts
+
+struct GFXfont
+{
+};
+
+inline GFXfont FreeSansBold24pt7b;
+
+namespace m5gfx
+{
+enum class textdatum_t
+{
+  top_left,
+  middle_center
+};
+}  // namespace m5gfx
+
+// ────────────────────── 画面制御スタブ ──────────────────────
+class M5GFX
+{
+public:
+  void init() {}
+  void initDMA() {}
+  void setRotation(int) {}
+  void setColorDepth(int) {}
+  void setBrightness(int) {}
+};
+
+class M5Canvas
+{
+public:
+  M5Canvas() = default;
+  explicit M5Canvas(M5GFX *) {}
+
+  void setColorDepth(int) {}
+  void setTextSize(int) {}
+  void setTextColor(uint16_t, uint16_t = 0) {}
+  void setFont(const fonts::FontStub *) {}
+  void setFont(const GFXfont *) {}
+  void setTextFont(int) {}
+  auto textWidth(const char *) const -> int { return 0; }
+  auto fontHeight() const -> int { return 0; }
+  void setCursor(int, int) {}
+  void setPsram(bool) {}
+  void initDMA() {}
+  void createSprite(int, int) {}
+  void fillRect(int, int, int, int, uint16_t) {}
+  void fillArc(int, int, int, int, float, float, uint16_t) {}
+  void fillScreen(uint16_t) {}
+  void drawLine(int, int, int, int, uint16_t) {}
+  void drawRect(int, int, int, int, uint16_t) {}
+  void drawPixel(int, int, uint16_t) {}
+  void print(const char *) {}
+  void printf(const char *, ...) {}
+  void drawRightString(const char *, int, int) {}
+  void drawString(const char *, int, int) {}
+  void pushSprite(int, int) {}
+  void setTextDatum(m5gfx::textdatum_t) {}
+};
+
+#endif  // STUBS_M5GFX_H

--- a/stubs/WiFi.h
+++ b/stubs/WiFi.h
@@ -1,0 +1,16 @@
+#ifndef STUBS_WIFI_H
+#define STUBS_WIFI_H
+
+// ────────────────────── WiFi 制御スタブ ──────────────────────
+constexpr int WIFI_OFF = 0;
+
+class WiFiClass
+{
+public:
+  void mode(int) {}
+  void disconnect(bool) {}
+};
+
+inline WiFiClass WiFi;
+
+#endif  // STUBS_WIFI_H

--- a/stubs/Wire.h
+++ b/stubs/Wire.h
@@ -1,0 +1,13 @@
+#ifndef STUBS_WIRE_H
+#define STUBS_WIRE_H
+
+// ────────────────────── I2C 通信スタブ ──────────────────────
+class TwoWire
+{
+public:
+  void begin(int, int) {}
+};
+
+inline TwoWire Wire;
+
+#endif  // STUBS_WIRE_H


### PR DESCRIPTION
## 概要 / Summary
- clang-tidy 実行時に不足する依存関係を解決するスタブヘッダーを追加しました。
- 主なソースファイル（src/main.cpp および modules 配下）に対して bugprone/performance 系チェックの clang-tidy を実行しました。

## テスト / Testing
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/main.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/modules/backlight.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/modules/display.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/modules/fps_display.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/modules/low_warning.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/modules/racing_indicator.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/modules/racing_mode.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w
- clang-tidy -config="{Checks: '-*,bugprone-*,performance-*', WarningsAsErrors: ''}" src/modules/sensor.cpp -- -Iinclude -Isrc -Istubs -std=gnu++17 -w


------
https://chatgpt.com/codex/tasks/task_e_68d9dbd88d088322b252ee59b12c55c8