### PR TITLE
照度初期化修正と平滑化ヘルパーの整理 / Fix lux initialization and refactor smoothing helper

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -12,7 +12,8 @@
 BrightnessMode currentBrightnessMode = BrightnessMode::Day;
 // ALS サンプルバッファ
 int luxSamples[MEDIAN_BUFFER_SIZE] = {};
-int luxSampleIndex = 0;  // 次に書き込むインデックス
+int luxSampleIndex = 0;              // 次に書き込むインデックス
+bool luxSamplesInitialized = false;  // 初期サンプルを埋めたかどうか
 
 // 直近取得した照度値
 int latestLux = 0;
@@ -52,6 +53,16 @@ void updateBacklightLevel()
 
   int currentLux = CoreS3.Ltr553.getAlsValue();
   latestLux = currentLux;
+  if (!luxSamplesInitialized)
+  {
+    // 初回はサンプルを同じ値で埋めて中央値が0にならないようにする
+    for (int &sample : luxSamples)
+    {
+      sample = currentLux;
+    }
+    luxSampleIndex = 0;
+    luxSamplesInitialized = true;
+  }
   // サンプルをリングバッファへ格納
   luxSamples[luxSampleIndex] = currentLux;
   luxSampleIndex = (luxSampleIndex + 1) % MEDIAN_BUFFER_SIZE;

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -29,6 +29,16 @@ static unsigned long lastPressureCheckMs = 0;
 static float prevPressureValue = std::numeric_limits<float>::quiet_NaN();
 static float prevWaterTempValue = std::numeric_limits<float>::quiet_NaN();
 
+// 平滑化を行うヘルパー
+static auto smoothValue(float current, float target, float alpha) -> float
+{
+  if (std::isnan(current))
+  {
+    return target;
+  }
+  return current + alpha * (target - current);
+}
+
 struct DisplayCache
 {
   float pressureAvg;
@@ -211,22 +221,9 @@ void updateGauges()
     recordedMaxOilTempTop = 0;
   }
 
-  if (std::isnan(smoothWaterTemp))
-  {
-    smoothWaterTemp = targetWaterTemp;
-  }
-  if (std::isnan(smoothOilTemp))
-  {
-    smoothOilTemp = targetOilTemp;
-  }
-  if (std::isnan(smoothOilPressure))
-  {
-    smoothOilPressure = pressureAvg;
-  }
-
-  smoothWaterTemp += 0.1F * (targetWaterTemp - smoothWaterTemp);
-  smoothOilTemp += 0.1F * (targetOilTemp - smoothOilTemp);
-  smoothOilPressure += OIL_PRESSURE_SMOOTHING_ALPHA * (pressureAvg - smoothOilPressure);
+  smoothWaterTemp = smoothValue(smoothWaterTemp, targetWaterTemp, 0.1F);
+  smoothOilTemp = smoothValue(smoothOilTemp, targetOilTemp, 0.1F);
+  smoothOilPressure = smoothValue(smoothOilPressure, pressureAvg, OIL_PRESSURE_SMOOTHING_ALPHA);
 
   float oilTempValue = smoothOilTemp;
   float pressureValue = smoothOilPressure;


### PR DESCRIPTION
### Motivation
- 起動時にALSの中央値が0になる誤判定を防ぎ、散在していた平滑化処理を共通化して保守性と初期挙動を改善します。 
- Prevent incorrect median ALS readings at startup and consolidate smoothing logic to improve maintainability and startup behavior.

### Description
- `src/modules/backlight.cpp` に `luxSamplesInitialized` を追加し、初回取得時に `luxSamples` を現在値で埋める処理を入れて中央値フィルタの誤判定を防止しました。 
- `src/modules/display.cpp` に `smoothValue` ヘルパーを導入し、既存の個別平滑化コードを置換して油圧／水温／油温の平滑化を共通化しました。

### Testing
- `clang-format -i src/modules/display.cpp src/modules/backlight.cpp` を実行してソース整形を適用しました（成功）。 / Ran `clang-format -i src/modules/display.cpp src/modules/backlight.cpp` to format sources (succeeded).
- `clang-tidy src/modules/display.cpp src/modules/backlight.cpp -- -Iinclude -Isrc` を実行しましたが、`M5CoreS3.h` や `M5GFX.h` 等のターゲットヘッダが見つからず多数の lint 警告で失敗しました（失敗）。 / Ran `clang-tidy src/modules/display.cpp src/modules/backlight.cpp -- -Iinclude -Isrc` but it failed due to missing headers (`M5CoreS3.h`, `M5GFX.h`) and lint errors (failed).
- `act -j build` はこの環境に `act` が無いため実行できませんでした（実行不可）。 / Could not run `act -j build` because `act` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888a8cd658832290a613d5e6031708)