### PR TITLE
FPS向上のためゲージ再描画を間引く / Throttle gauge redraws to improve FPS

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -18,6 +18,10 @@ M5Canvas mainCanvas(&display);
 
 static bool pressureGaugeInitialized = false;
 static bool waterGaugeInitialized = false;
+// 各パーツの最短再描画間隔を管理し、不要な再描画を抑制する
+static unsigned long lastOilRedrawMs = 0;
+static unsigned long lastPressureRedrawMs = 0;
+static unsigned long lastWaterRedrawMs = 0;
 
 float recordedMaxOilPressure = 0.0F;
 float recordedMaxWaterTemp = 0.0F;
@@ -98,16 +102,26 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
   const int TOPBAR_Y = 0;
   const int TOPBAR_H = 50;
   const int GAUGE_H = 170;
+  constexpr unsigned long OIL_REDRAW_INTERVAL_MS = 100UL;
+  constexpr unsigned long PRESSURE_REDRAW_INTERVAL_MS = 50UL;
+  constexpr unsigned long WATER_REDRAW_INTERVAL_MS = 100UL;
+  unsigned long nowMs = millis();
 
   // 水温は0.05度以上、油温は0.1度以上、油圧は0.05bar以上変化したら更新する
   bool oilChanged = std::isnan(displayCache.oilTemp) || fabs(oilTemp - displayCache.oilTemp) >= 0.1F ||
                     (maxOilTemp != displayCache.maxOilTemp);
   bool pressureChanged = std::isnan(displayCache.pressureAvg) || fabs(pressureAvg - displayCache.pressureAvg) >= 0.05F;
   bool waterChanged = std::isnan(displayCache.waterTempAvg) || fabs(waterTempAvg - displayCache.waterTempAvg) >= 0.05F;
+  bool shouldRedrawOil =
+      oilChanged && (std::isnan(displayCache.oilTemp) || nowMs - lastOilRedrawMs >= OIL_REDRAW_INTERVAL_MS);
+  bool shouldRedrawPressure =
+      pressureChanged && (!pressureGaugeInitialized || nowMs - lastPressureRedrawMs >= PRESSURE_REDRAW_INTERVAL_MS);
+  bool shouldRedrawWater =
+      waterChanged && (!waterGaugeInitialized || nowMs - lastWaterRedrawMs >= WATER_REDRAW_INTERVAL_MS);
 
   mainCanvas.setTextColor(COLOR_WHITE);
 
-  if (oilChanged)
+  if (shouldRedrawOil)
   {
     mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
     if (oilTemp >= 199.0F)
@@ -122,9 +136,10 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
     drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
     displayCache.oilTemp = oilTemp;
     displayCache.maxOilTemp = maxOilTemp;
+    lastOilRedrawMs = nowMs;
   }
 
-  if (pressureChanged || !pressureGaugeInitialized)
+  if (shouldRedrawPressure || !pressureGaugeInitialized)
   {
     if (!pressureGaugeInitialized)
     {
@@ -135,9 +150,10 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
                      prevPressureValue, 0.5f, isUseDecimal, 0, 60, !pressureGaugeInitialized);
     pressureGaugeInitialized = true;
     displayCache.pressureAvg = pressureAvg;
+    lastPressureRedrawMs = nowMs;
   }
 
-  if (waterChanged || !waterGaugeInitialized)
+  if (shouldRedrawWater || !waterGaugeInitialized)
   {
     if (!waterGaugeInitialized)
     {
@@ -148,6 +164,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
                      WATER_TEMP_METER_MIN);
     waterGaugeInitialized = true;
     displayCache.waterTempAvg = waterTempAvg;
+    lastWaterRedrawMs = nowMs;
   }
 
   bool warnChanged = false;
@@ -167,7 +184,8 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, i
   bool racingChanged = drawRacingIndicator(mainCanvas);
 
   // 値が更新されたときのみスプライトを転送する
-  if (oilChanged || pressureChanged || waterChanged || fpsChanged || warnChanged || racingChanged)
+  if (shouldRedrawOil || shouldRedrawPressure || shouldRedrawWater || !pressureGaugeInitialized || !waterGaugeInitialized ||
+      fpsChanged || warnChanged || racingChanged)
   {
     mainCanvas.pushSprite(0, 0);
   }


### PR DESCRIPTION
### Motivation
- 表示更新負荷を下げて実効FPSを安定化させるため、`pushSprite` 呼び出し回数を減らす必要がありました。/ Reduce `pushSprite` calls to lower rendering load and stabilize effective FPS.
- 微小な値変化で頻繁に再描画される点を抑えつつ、表示の応答性は維持することを狙っています。/ Throttle insignificant updates while keeping UI responsiveness.

### Description
- `src/modules/display.cpp` に各パーツ（油温バー・油圧・水温）の最短再描画間隔用タイムスタンプ `lastOilRedrawMs` / `lastPressureRedrawMs` / `lastWaterRedrawMs` を追加しました。/ Added per-component timestamp caches in `src/modules/display.cpp`.
- `renderDisplayAndLog` に `OIL_REDRAW_INTERVAL_MS`, `PRESSURE_REDRAW_INTERVAL_MS`, `WATER_REDRAW_INTERVAL_MS` を導入し、`shouldRedraw*` ブールで再描画可否を判定するロジックを追加しました。/ Introduced redraw interval constants and `shouldRedraw*` booleans in `renderDisplayAndLog`.
- 実際に再描画を行った場合にのみキャッシュとタイムスタンプを更新するようにし、`pushSprite` の発行判定もこれらのフラグに合わせて調整しました。/ Update caches/timestamps only on actual redraw and aligned `pushSprite` trigger to those flags.

### Testing
- `clang-format -i src/modules/display.cpp` は実行済みで整形を適用しました（成功）。/ Ran `clang-format -i src/modules/display.cpp` (succeeded).
- `clang-tidy src/modules/display.cpp -- -Iinclude -Isrc` は実行しましたが、既存コード起因の大量警告と未解決ヘッダ（`M5GFX.h`）により失敗しました。/ Ran `clang-tidy ...` but it failed due to many pre-existing warnings treated as errors and missing header `M5GFX.h` (failed).
- CIローカル実行のための `act -j build` と `platformio run` はこの環境にインストールされておらず実行できませんでした。/ `act -j build` and `platformio run` could not be executed because those tools are not available in this environment.
- 変更は `renderDisplayAndLog` の再描画判定と `pushSprite` トリガー周りに限定しており、見た目の挙動確認は実機での確認を推奨します。/ Changes are limited to redraw decision and `pushSprite` triggering; visual validation should be done on target hardware.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab182d621083229383054c4cc8e255)