### PR TITLE
display.cpp のインデントと単一行 if をブロック化 / Normalize indentation and expand single-line if in display.cpp

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -29,8 +29,12 @@ struct DisplayCache
   float waterTempAvg;
   float oilTemp;
   int16_t maxOilTemp;
-} displayCache = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
-                  std::numeric_limits<float>::quiet_NaN(), INT16_MIN};
+} displayCache = {
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    INT16_MIN,
+};
 
 // ────────────────────── 油温バー描画 ──────────────────────
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
@@ -72,7 +76,10 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
     canvas.drawPixel(tx, Y - 2, COLOR_WHITE);
     canvas.setCursor(tx - 10, Y - 14);
     canvas.printf("%d", m);
-    if (m == ALERT_TEMP) canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
+    if (m == ALERT_TEMP)
+    {
+      canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
+    }
   }
 
   canvas.setCursor(X, Y + H + 4);


### PR DESCRIPTION
### Motivation
- 差分レビューの可読性向上と将来の追記に備えたスタイル統一のため、挙動を変えずに整形を行いました / Improve diff reviewability and make future edits safer by applying non-behavioral formatting changes.

### Description
- `src/modules/display.cpp` の `DisplayCache` 初期化子を複数行に分割し、`drawOilTemperatureTopBar` 内の単一行 `if` をブロック形式に変更しました（動作は変更していません）；レビュワー: `copilot` / Split the `DisplayCache` initializer into multiple lines and converted the single-line `if` in `drawOilTemperatureTopBar` into a block form in `src/modules/display.cpp`; these are formatting-only changes and do not alter behavior; Reviewer: `copilot`.

### Testing
- 自動チェックとして `clang-format -i src/modules/display.cpp` を実行して整形を適用できたことを確認しましたが、`clang-tidy src/modules/display.cpp -- -Isrc -Iinclude` は環境内で `M5GFX.h` が見つからず完走できませんでした（成功 / 失敗） / Ran `clang-format -i src/modules/display.cpp` successfully, and attempted `clang-tidy src/modules/display.cpp -- -Isrc -Iinclude` which failed due to missing `M5GFX.h` in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1d68e0ec83228001210d639388c7)