### PR TITLE
[不具合修正 / Bug Fix] イグニッション時のI2Cフリーズを防止 / Prevent I2C freeze during ignition

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,9 @@ void setup()
   pinMode(9, INPUT_PULLUP);
   pinMode(8, INPUT_PULLUP);
   Wire.begin(9, 8);
+  // クランキング時のノイズでI2Cが不安定になるため低速化とタイムアウトを設定
+  Wire.setClock(100000);
+  Wire.setTimeOut(5);
 
 #if !DEMO_MODE_ENABLED
   // デモモードでなければADS1015を初期化し、失敗時は画面にエラーを表示


### PR DESCRIPTION
### Motivation
- イグニッション（クランキング）時の電源ノイズでI2Cバスが不安定になりM5Stackが黒画面でフリーズする問題を緩和するため。 / To mitigate freezes where the M5Stack remains black during ignition due to I2C instability caused by cranking power noise.

### Description
- `Wire.begin(9, 8);` の直後に `Wire.setClock(100000);` と `Wire.setTimeOut(5);` を追加しました（I2Cの低速化とタイムアウト設定）。UIや描画ロジックには変更を加えていません。 / Added `Wire.setClock(100000);` and `Wire.setTimeOut(5);` immediately after `Wire.begin(9, 8);` to slow the I2C bus and set a timeout; no UI or rendering logic was changed.

### Testing
- `clang-format -i src/main.cpp` を実行済みで整形を適用しましたが、`clang-tidy src/main.cpp -- -Isrc -Iinclude` は組込みヘッダ（`M5CoreS3.h`）がないため完走できず、`act -j build` と `pio run` は環境に `act` / `pio` がないため実行できませんでした。 / Ran `clang-format -i src/main.cpp`; `clang-tidy src/main.cpp -- -Isrc -Iinclude` could not complete due to missing embedded headers (`M5CoreS3.h`), and `act -j build` and `pio run` could not be executed because `act` and `pio` are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad47d95f848322bbed0c7a1c784fd8)