### PR TITLE
READMEの体裁修正とライセンス注記の明確化 / Fix README formatting and clarify license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-#M5Stack CoreS3 Multi - Gauge
-#M5Stack CoreS3 マルチメーター
+# M5Stack CoreS3 Multi Gauge
+# M5Stack CoreS3 マルチメーター
 
 [![PlatformIO Build](https://github.com/puriso/racing_gauge/actions/workflows/pio-build.yml/badge.svg?branch=main)](https://github.com/puriso/racing_gauge/actions/workflows/pio-build.yml)
 
@@ -199,8 +199,8 @@ The temperature sensor is a thermistor; typical resistance values are shown belo
 ---
 
 ### License
-このプロジェクトは MIT ライセンスではありません。著作権は作者が保持します。
-This project is not licensed under the MIT License. All rights reserved by the author.
+このプロジェクトは MIT ライセンスではありません。著作権は作者が保持します。詳細は `LICENSE` を参照してください。
+This project is not licensed under the MIT License. All rights are reserved by the author. See `LICENSE` for details.
 
 ---
 


### PR DESCRIPTION
### Motivation
- READMEの先頭見出しと英語タイトル表記、ライセンス注記を正しく表示・明確化するために軽微な内容を整理しました / Correct README heading formatting, normalize the English title, and clarify the license note.

### Description
- `README.md` の見出し記法を修正（`#` の後にスペース追加）、英語タイトルを `Multi - Gauge` から `Multi Gauge` に変更し、ライセンス節に `LICENSE` 参照を追記して英語文面を調整しました / In `README.md` fixed the heading markup (add space after `#`), changed the English title from `Multi - Gauge` to `Multi Gauge`, and added a `LICENSE` reference plus minor English phrasing adjustments.

### Testing
- 実行した自動検査は ` .clang-format`、`.clang-tidy`、`act -j build` の3つで、いずれも実行コマンドが見つからず実行できませんでした（`command not found`） / Automated checks attempted: `.clang-format`, `.clang-tidy`, and `act -j build`, each could not be run because the commands were not found (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d907aaf97083228f6a019e2fc76796)