### PR TITLE
[JP/EN] アークメーター三角関数キャッシュ化 / Cache trig functions for arc meter tick rendering

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -4,6 +4,7 @@
 #include <M5GFX.h>  // 必要なライブラリをインクルード
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -136,11 +137,30 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   {
     // 目盛ラベルと目盛り線を描画
     int tickCount = static_cast<int>((maxValue - minValue) / tickStep) + 1;
-    for (float i = 0; i <= tickCount - 1; i += 1)
+    constexpr int TRIG_CACHE_MAX = 128;
+    static std::array<float, TRIG_CACHE_MAX> sinCache = {};
+    static std::array<float, TRIG_CACHE_MAX> cosCache = {};
+    static int cachedTickCount = -1;
+
+    // 目盛の角度に対応する三角関数を初期化時にキャッシュ
+    if (tickCount != cachedTickCount)
+    {
+      for (int i = 0; i < tickCount && i < TRIG_CACHE_MAX; ++i)
+      {
+        float angle = 270 - ((270.0f / (tickCount - 1)) * i);  // 開始位置のロジックを維持
+        float rad = radians(angle);
+        sinCache[i] = sinf(rad);
+        cosCache[i] = cosf(rad);
+      }
+      cachedTickCount = tickCount;
+    }
+
+    int drawableTickCount = std::min(tickCount, TRIG_CACHE_MAX);
+    for (int i = 0; i < drawableTickCount; ++i)
     {
       float scaledValue = minValue + (tickStep * i);
-      float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
-      float rad = radians(angle);
+      float sinVal = sinCache[i];
+      float cosVal = cosCache[i];
 
       // 主要目盛かどうかを判定（majorTickStep が負なら従来と同じ判定）
       bool isMajorTick;
@@ -158,10 +178,10 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
       int innerRadius = isMajorTick ? (RADIUS - ARC_WIDTH - 10) : (RADIUS - ARC_WIDTH - 8);
       int outerRadius = isMajorTick ? (RADIUS - ARC_WIDTH - 5) : (RADIUS - ARC_WIDTH - 7);
 
-      int lineX1 = CENTER_X_CORRECTED + (cosf(rad) * innerRadius);
-      int lineY1 = CENTER_Y_CORRECTED - (sinf(rad) * innerRadius);
-      int lineX2 = CENTER_X_CORRECTED + (cosf(rad) * outerRadius);
-      int lineY2 = CENTER_Y_CORRECTED - (sinf(rad) * outerRadius);
+      int lineX1 = CENTER_X_CORRECTED + (cosVal * innerRadius);
+      int lineY1 = CENTER_Y_CORRECTED - (sinVal * innerRadius);
+      int lineX2 = CENTER_X_CORRECTED + (cosVal * outerRadius);
+      int lineY2 = CENTER_Y_CORRECTED - (sinVal * outerRadius);
 
       canvas.drawLine(lineX1, lineY1, lineX2, lineY2, COLOR_WHITE);
 
@@ -169,8 +189,8 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
 
       if (drawLabel)
       {
-        int labelX = CENTER_X_CORRECTED + (cosf(rad) * (RADIUS - ARC_WIDTH - 15));
-        int labelY = CENTER_Y_CORRECTED - (sinf(rad) * (RADIUS - ARC_WIDTH - 15));
+        int labelX = CENTER_X_CORRECTED + (cosVal * (RADIUS - ARC_WIDTH - 15));
+        int labelY = CENTER_Y_CORRECTED - (sinVal * (RADIUS - ARC_WIDTH - 15));
 
         char labelText[6];
         snprintf(labelText, sizeof(labelText), "%.0f", scaledValue);


### PR DESCRIPTION
### Motivation
- 概要 (JP) / Summary (EN): `src/DrawFillArcMeter.h` の目盛描画で毎回 `sinf/cosf` を計算していたため、初期化時に角度ごとの三角関数をキャッシュして描画コストを下げる変更を行いました (Cache per-angle sin/cos to reduce repeated trig computations in tick rendering).
- 目標は静的描画時や目盛再生成が少ない場面での不要な三角関数計算を削減して描画負荷／消費電力を下げることです。 

### Description
- `#include <array>` を追加し、固定長キャッシュ `TRIG_CACHE_MAX` として `sinCache` / `cosCache` の配列を導入しました。 
- `tickCount` が変化したときのみループで `sinf(rad)` / `cosf(rad)` を計算してキャッシュに格納し、描画ループではキャッシュ値を参照するように置換しました。 
- キャッシュ使用時は `drawableTickCount = std::min(tickCount, TRIG_CACHE_MAX)` により上限を保ち、描画ループのインデックスを `int` にして安定化させました。 
- コード整形のために `clang-format -i src/DrawFillArcMeter.h` を実行しました。 

### Testing
- `clang-format -i src/DrawFillArcMeter.h` は成功しました。 
- `clang-tidy src/DrawFillArcMeter.h --` は実行しましたが、環境に `M5GFX.h` が無く解析できず多数の診断（環境依存のエラー含む）で失敗しました。 
- `act -j build` はこの実行環境に `act` が無いため実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6535bafac8322aae72c4cb58f2ca1)